### PR TITLE
Allow blank GEO overrides

### DIFF
--- a/redical_core/src/event.rs
+++ b/redical_core/src/event.rs
@@ -9,6 +9,7 @@ use redical_ical::{
     RenderingContext,
     content_line::ContentLine,
     properties::{
+        ICalendarGeoProperty,
         ICalendarProperty,
         ICalendarDateTimeProperty,
         EventProperty,
@@ -315,7 +316,11 @@ impl IndexedProperties {
     pub fn extract_geo_point(&self) -> Option<GeoPoint> {
         self.geo
             .as_ref()
-            .map(GeoPoint::from)
+            .and_then(
+                |geo_property| {
+                    GeoPoint::try_from(geo_property.get_lat_long_pair()).ok()
+                }
+            )
     }
 
     pub fn extract_class(&self) -> Option<String> {

--- a/redical_core/src/event.rs
+++ b/redical_core/src/event.rs
@@ -617,11 +617,15 @@ impl Event {
         }
 
         if let Some(ref mut indexed_geo) = self.indexed_geo {
-            if let Some(overridden_geo) = &event_occurrence_override
-                .indexed_properties
-                .extract_geo_point()
-            {
-                indexed_geo.insert_override(timestamp, &HashSet::from([overridden_geo.clone()]));
+            // Allow events with GEO defined to be overridden to make GEO blank (specific events online only).
+            if event_occurrence_override.indexed_properties.geo.is_some() {
+                if let Some(overridden_geo_point) = &event_occurrence_override.indexed_properties.extract_geo_point() {
+                    // If a non-blank GEO property defined override is present, insert this.
+                    indexed_geo.insert_override(timestamp, &HashSet::from([overridden_geo_point.to_owned()]));
+                } else {
+                    // If a blank GEO property defined override is present, insert the blank.
+                    indexed_geo.insert_override(timestamp, &HashSet::from([]));
+                }
             }
         } else {
             self.rebuild_indexed_geo()?;

--- a/redical_core/src/event_instance.rs
+++ b/redical_core/src/event_instance.rs
@@ -17,6 +17,7 @@ use redical_ical::{
     properties::{
         ICalendarProperty,
         ICalendarDateTimeProperty,
+        ICalendarGeoProperty,
         CategoriesProperty,
         LocationTypeProperty,
         ClassProperty,
@@ -108,8 +109,12 @@ impl EventInstance {
         event_occurrence_override: Option<&EventOccurrenceOverride>,
     ) -> Option<GeoProperty> {
         if let Some(event_occurrence_override) = event_occurrence_override {
-            if event_occurrence_override.indexed_properties.geo.is_some() {
-                return event_occurrence_override.indexed_properties.geo.to_owned();
+            if let Some(overridden_geo_property) = event_occurrence_override.indexed_properties.geo.as_ref() {
+                if overridden_geo_property.is_present() {
+                    return Some(overridden_geo_property.to_owned());
+                } else {
+                    return None;
+                }
             }
         }
 

--- a/redical_core/src/geo_index.rs
+++ b/redical_core/src/geo_index.rs
@@ -7,7 +7,6 @@ use rstar::primitives::GeomWithData;
 use std::hash::{Hash, Hasher};
 
 use crate::{IndexedConclusion, InvertedCalendarIndexTerm};
-use redical_ical::properties::ICalendarGeoProperty;
 
 #[derive(Debug, PartialEq, Eq, Clone)]
 pub enum GeoDistance {
@@ -151,16 +150,22 @@ pub struct GeoPoint {
     pub long: f64,
 }
 
-impl<P> From<&P> for GeoPoint
-where
-    P: ICalendarGeoProperty,
-{
-    #[inline]
-    fn from(property: &P) -> Self {
-        GeoPoint::new(
-            property.get_latitude(),
-            property.get_longitude(),
-        )
+impl TryFrom<Option<(f64, f64)>> for GeoPoint {
+    type Error = String;
+
+    fn try_from(coords: Option<(f64, f64)>) -> Result<Self, Self::Error> {
+        if let Some((latitude, longitude)) = coords {
+            Ok(
+                GeoPoint::new(
+                    latitude,
+                    longitude,
+                )
+            )
+        } else {
+            Err(
+                String::from("Cannot build blank GeoPoint")
+            )
+        }
     }
 }
 

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -5,6 +5,8 @@ use crate::geo_index::GeoPoint;
 
 use crate::utils::{KeyValuePair, UpdatedHashMapMembers, UpdatedSetMembers};
 
+use redical_ical::properties::ICalendarGeoProperty;
+
 #[derive(Default, Debug, PartialEq, Eq, Clone)]
 pub struct InvertedCalendarIndexTerm {
     pub events: HashMap<String, IndexedConclusion>,
@@ -297,7 +299,9 @@ where
         };
 
         if let Some(geo_property) = event.indexed_properties.geo.as_ref() {
-            indexed_geo.insert(&GeoPoint::from(geo_property));
+            if let Ok(geo_point) = GeoPoint::try_from(geo_property.get_lat_long_pair()) {
+                indexed_geo.insert(&geo_point);
+            }
         }
 
         for (timestamp, event_override) in event.overrides.iter() {

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -305,9 +305,19 @@ where
         }
 
         for (timestamp, event_override) in event.overrides.iter() {
-            if let Some(overridden_geo) = &event_override.indexed_properties.extract_geo_point() {
-                indexed_geo
-                    .insert_override(timestamp.to_owned(), &HashSet::from([overridden_geo.clone()]));
+            if event_override.indexed_properties.geo.is_none() {
+                continue;
+            };
+
+            let timestamp = timestamp.to_owned();
+
+            // Allow events with GEO defined to be overridden to make GEO blank (specific events online only).
+            if let Some(overridden_geo_point) = &event_override.indexed_properties.extract_geo_point() {
+                // If a non-blank GEO property defined override is present, insert this.
+                indexed_geo.insert_override(timestamp, &HashSet::from([overridden_geo_point.to_owned()]));
+            } else {
+                // If a blank GEO property defined override is present, insert the blank.
+                indexed_geo.insert_override(timestamp, &HashSet::from([]));
             }
         }
 

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -399,11 +399,9 @@ where
         // Check for currently indexed terms NOT present in the override, and add them as an exception to
         // IndexedConclusion::Include (include all except timestamp).
         for excluded_term in indexed_terms_set.difference(override_terms_set) {
-            self.terms.get_mut(excluded_term).map(|indexed_term| {
+            if let Some(indexed_term) = self.terms.get_mut(excluded_term) {
                 indexed_term.insert_exception(timestamp);
-
-                indexed_term
-            });
+            }
         }
 
         // Check for overridden terms NOT already currently indexed, and add them as an

--- a/redical_core/src/queries/query_parser.rs
+++ b/redical_core/src/queries/query_parser.rs
@@ -4,10 +4,13 @@ use crate::queries::indexed_property_filters::{
     WhereConditional, WhereConditionalProperty, WhereOperator,
 };
 
+use crate::geo_index::GeoPoint;
 use crate::queries::query::Query;
 use crate::queries::results::QueryableEntity;
 
 use crate::{GeoDistance, KeyValuePair};
+
+use redical_ical::properties::ICalendarGeoProperty;
 
 use redical_ical::properties::query::{
     QueryProperty,
@@ -321,8 +324,12 @@ fn x_geo_query_property_to_where_conditional(x_geo_property: &XGeoProperty) -> O
             },
         };
 
+    let Some((latitude, longitude)) = x_geo_property.get_lat_long_pair() else {
+        return None;
+    };
+
     Some(WhereConditional::Property(
-        WhereConditionalProperty::Geo(x_geo_distance, x_geo_property.into()),
+        WhereConditionalProperty::Geo(x_geo_distance, GeoPoint::from((latitude, longitude))),
     ))
 }
 
@@ -365,7 +372,6 @@ mod test {
 
     use std::str::FromStr;
 
-    use crate::GeoPoint;
     use crate::testing::macros::build_property_from_ical;
 
     use crate::queries::indexed_property_filters::{

--- a/redical_core/src/queries/query_parser.rs
+++ b/redical_core/src/queries/query_parser.rs
@@ -324,9 +324,7 @@ fn x_geo_query_property_to_where_conditional(x_geo_property: &XGeoProperty) -> O
             },
         };
 
-    let Some((latitude, longitude)) = x_geo_property.get_lat_long_pair() else {
-        return None;
-    };
+    let (latitude, longitude) = x_geo_property.get_lat_long_pair()?;
 
     Some(WhereConditional::Property(
         WhereConditionalProperty::Geo(x_geo_distance, GeoPoint::from((latitude, longitude))),

--- a/redical_core/src/queries/results_ordering.rs
+++ b/redical_core/src/queries/results_ordering.rs
@@ -12,6 +12,7 @@ use redical_ical::{
     content_line::ContentLine,
     properties::{
         ICalendarProperty,
+        ICalendarGeoProperty,
         DTStartProperty,
         query::x_order_by::XOrderByProperty,
     },
@@ -72,11 +73,15 @@ impl OrderingCondition {
                         .indexed_properties
                         .geo
                         .clone()
-                        .map(|event_instance_geo| {
-                            let event_instance_geo_point = GeoPoint::from(&event_instance_geo);
+                        .and_then(|event_instance_geo| {
+                            let Ok(event_instance_geo_point) = GeoPoint::try_from(event_instance_geo.get_lat_long_pair()) else {
+                                return None;
+                            };
 
-                            GeoDistance::new_from_meters_float(
-                                event_instance_geo_point.haversine_distance(ordering_geo_point),
+                            Some(
+                                GeoDistance::new_from_meters_float(
+                                    event_instance_geo_point.haversine_distance(ordering_geo_point),
+                                )
                             )
                         });
 
@@ -91,11 +96,15 @@ impl OrderingCondition {
                         .indexed_properties
                         .geo
                         .as_ref()
-                        .map(|event_instance_geo| {
-                            let event_instance_geo_point = GeoPoint::from(event_instance_geo);
+                        .and_then(|event_instance_geo| {
+                            let Ok(event_instance_geo_point) = GeoPoint::try_from(event_instance_geo.get_lat_long_pair()) else {
+                                return None;
+                            };
 
-                            GeoDistance::new_from_meters_float(
-                                event_instance_geo_point.haversine_distance(ordering_geo_point),
+                            Some(
+                                GeoDistance::new_from_meters_float(
+                                    event_instance_geo_point.haversine_distance(ordering_geo_point),
+                                )
                             )
                         });
 
@@ -121,11 +130,15 @@ impl OrderingCondition {
                         .indexed_properties
                         .geo
                         .clone()
-                        .map(|event_geo| {
-                            let event_geo_point = GeoPoint::from(&event_geo);
+                        .and_then(|event_geo| {
+                            let Ok(event_geo_point) = GeoPoint::try_from(event_geo.get_lat_long_pair()) else {
+                                return None;
+                            };
 
-                            GeoDistance::new_from_meters_float(
-                                event_geo_point.haversine_distance(ordering_geo_point),
+                            Some(
+                                GeoDistance::new_from_meters_float(
+                                    event_geo_point.haversine_distance(ordering_geo_point),
+                                )
                             )
                         });
 
@@ -140,11 +153,15 @@ impl OrderingCondition {
                         .indexed_properties
                         .geo
                         .as_ref()
-                        .map(|event_geo| {
-                            let event_geo_point = GeoPoint::from(event_geo);
+                        .and_then(|event_geo| {
+                            let Ok(event_geo_point) = GeoPoint::try_from(event_geo.get_lat_long_pair()) else {
+                                return None;
+                            };
 
-                            GeoDistance::new_from_meters_float(
-                                event_geo_point.haversine_distance(ordering_geo_point),
+                            Some(
+                                GeoDistance::new_from_meters_float(
+                                    event_geo_point.haversine_distance(ordering_geo_point),
+                                )
                             )
                         });
 

--- a/redical_ical/src/properties/mod.rs
+++ b/redical_ical/src/properties/mod.rs
@@ -56,8 +56,24 @@ where
 }
 
 pub trait ICalendarGeoProperty {
-    fn get_latitude(&self) -> f64;
-    fn get_longitude(&self) -> f64;
+    fn get_latitude(&self) -> Option<f64>;
+    fn get_longitude(&self) -> Option<f64>;
+
+    fn get_lat_long_pair(&self) -> Option<(f64, f64)> {
+        if let (Some(latitude), Some(longitude)) = (self.get_latitude(), self.get_longitude()) {
+            Some((latitude, longitude))
+        } else {
+            None
+        }
+    }
+
+    fn is_present(&self) -> bool {
+        !self.is_blank()
+    }
+
+    fn is_blank(&self) -> bool {
+        self.get_latitude().is_none() || self.get_longitude().is_none()
+    }
 }
 
 pub trait ICalendarDateTimeProperty {

--- a/redical_ical/src/properties/query/x_geo.rs
+++ b/redical_ical/src/properties/query/x_geo.rs
@@ -144,12 +144,16 @@ impl ICalendarProperty for XGeoProperty {
 }
 
 impl ICalendarGeoProperty for XGeoProperty {
-    fn get_latitude(&self) -> f64 {
-        self.latitude.to_owned().into()
+    fn is_blank(&self) -> bool {
+        false
     }
 
-    fn get_longitude(&self) -> f64 {
-        self.longitude.to_owned().into()
+    fn get_latitude(&self) -> Option<f64> {
+        Some(self.latitude.to_owned().into())
+    }
+
+    fn get_longitude(&self) -> Option<f64> {
+        Some(self.longitude.to_owned().into())
     }
 }
 

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -908,7 +908,7 @@ mod integration {
                     "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
                     "CATEGORIES:CATEGORY_ONE,OVERRIDDEN_CATEGORY", // <= Overridden
                     "LOCATION-TYPE:X-KEY=VALUE:LOCATION_TYPE",
-                    "GEO:;",                                       // <= Overridden
+                    // "GEO:;",                                    // <= Overridden (removed from EventInstance because blank)
                     "X-SPACES-BOOKED:12",                          // <= Overridden
                 ],
             ],
@@ -1160,7 +1160,7 @@ mod integration {
                         "DTEND:20210105T190000Z",
                         "DTSTART:20210105T183000Z",
                         "DURATION:PT30M",
-                        "GEO:;",
+                        // "GEO:;", <= Overridden (removed from EventInstance because blank)
                         "RECURRENCE-ID;VALUE=DATE-TIME:20210105T183000Z",
                         "RELATED-TO;RELTYPE=PARENT:PARENT_UID_OVERRIDE",
                         "SUMMARY:Overridden Event in Bristol on Tuesdays and Thursdays at 6:30PM (running online)",

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -317,6 +317,7 @@ mod integration {
                     "CATEGORIES:CATEGORY_ONE,OVERRIDDEN_CATEGORY",
                     "LOCATION-TYPE:OVERRIDDEN_LOCATION_TYPE",
                     "X-SPACES-BOOKED:12",
+                    "GEO:;",
                 ],
             );
 
@@ -355,6 +356,7 @@ mod integration {
                         "CATEGORIES:CATEGORY_ONE,OVERRIDDEN_CATEGORY",
                         "LOCATION-TYPE:OVERRIDDEN_LOCATION_TYPE",
                         "X-SPACES-BOOKED:12",
+                        "GEO:;",
                     ],
                 ],
             );
@@ -391,6 +393,7 @@ mod integration {
                         "CATEGORIES:CATEGORY_ONE,OVERRIDDEN_CATEGORY",
                         "LOCATION-TYPE:OVERRIDDEN_LOCATION_TYPE",
                         "X-SPACES-BOOKED:12",
+                        "GEO:;",
                     ],
                 ],
             );
@@ -862,6 +865,7 @@ mod integration {
                 "LAST-MODIFIED:20210501T090000Z",
                 "CATEGORIES:CATEGORY_ONE,OVERRIDDEN_CATEGORY",
                 "X-SPACES-BOOKED:12",
+                "GEO:;",
             ],
         );
 
@@ -876,10 +880,10 @@ mod integration {
                     "RECURRENCE-ID;VALUE=DATE-TIME:20210104T170000Z",
                     "UID:EVENT_IN_OXFORD_MON_WED",
                     "DURATION:PT30M",
-                    "SUMMARY:Overridden event in Oxford summary text",  // <= Overridden
+                    "SUMMARY:Overridden event in Oxford summary text", // <= Overridden
                     "RELATED-TO;RELTYPE=PARENT:OVERRIDDEN_PARENT_UID", // <= Overridden
-                    "CATEGORIES:OVERRIDDEN_CATEGORY",                   // <= Overridden
-                    "LOCATION-TYPE:OVERRIDDEN_LOCATION_TYPE",           // <= Overridden
+                    "CATEGORIES:OVERRIDDEN_CATEGORY",                  // <= Overridden
+                    "LOCATION-TYPE:OVERRIDDEN_LOCATION_TYPE",          // <= Overridden
                     "GEO:51.751365550307604;-1.2601196837753945",
                 ],
                 [
@@ -904,7 +908,7 @@ mod integration {
                     "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
                     "CATEGORIES:CATEGORY_ONE,OVERRIDDEN_CATEGORY", // <= Overridden
                     "LOCATION-TYPE:X-KEY=VALUE:LOCATION_TYPE",
-                    "GEO:51.751365550307604;-1.2601196837753945",
+                    "GEO:;",                                       // <= Overridden
                     "X-SPACES-BOOKED:12",                          // <= Overridden
                 ],
             ],
@@ -923,10 +927,10 @@ mod integration {
                     "RECURRENCE-ID;VALUE=DATE-TIME:20210104T170000Z",
                     "UID:EVENT_IN_OXFORD_MON_WED",
                     "DURATION:PT30M",
-                    "SUMMARY:Overridden event in Oxford summary text",  // <= Overridden
+                    "SUMMARY:Overridden event in Oxford summary text", // <= Overridden
                     "RELATED-TO;RELTYPE=PARENT:OVERRIDDEN_PARENT_UID", // <= Overridden
-                    "CATEGORIES:OVERRIDDEN_CATEGORY",                   // <= Overridden
-                    "LOCATION-TYPE:OVERRIDDEN_LOCATION_TYPE",           // <= Overridden
+                    "CATEGORIES:OVERRIDDEN_CATEGORY",                  // <= Overridden
+                    "LOCATION-TYPE:OVERRIDDEN_LOCATION_TYPE",          // <= Overridden
                     "GEO:51.751365550307604;-1.2601196837753945",
                 ],
             ],
@@ -1063,9 +1067,10 @@ mod integration {
             "20210105T183000Z",
             [
                 "LAST-MODIFIED:20210501T090000Z",
-                "SUMMARY:Overridden Event in Bristol on Tuesdays and Thursdays at 6:30PM",
+                "SUMMARY:Overridden Event in Bristol on Tuesdays and Thursdays at 6:30PM (running online)",
                 "RELATED-TO;RELTYPE=PARENT:PARENT_UID_OVERRIDE",
                 "CATEGORIES:CATEGORY_OVERRIDE",
+                "GEO:;",
             ],
         );
 
@@ -1155,10 +1160,10 @@ mod integration {
                         "DTEND:20210105T190000Z",
                         "DTSTART:20210105T183000Z",
                         "DURATION:PT30M",
-                        "GEO:51.454481838260214;-2.588329192623361",
+                        "GEO:;",
                         "RECURRENCE-ID;VALUE=DATE-TIME:20210105T183000Z",
                         "RELATED-TO;RELTYPE=PARENT:PARENT_UID_OVERRIDE",
-                        "SUMMARY:Overridden Event in Bristol on Tuesdays and Thursdays at 6:30PM",
+                        "SUMMARY:Overridden Event in Bristol on Tuesdays and Thursdays at 6:30PM (running online)",
                         "UID:OVERRIDDEN_EVENT_IN_BRISTOL_TUE_THU",
                     ],
                 ],
@@ -1354,24 +1359,24 @@ mod integration {
             connection,
             "TEST_CALENDAR_UID",
             [
+                "X-GEO;DIST=100MI:51.454481838260214;-2.588329192623361",
                 "X-FROM;PROP=DTSTART;OP=GT;TZID=Europe/London:20210105T180000Z",
-                "X-UNTIL;PROP=DTSTART;OP=LTE;TZID=UTC:20210630T180000Z",
+                "X-UNTIL;PROP=DTSTART;OP=LTE;TZID=UTC:20210715T180000Z",
                 "(",
-                    "X-UID:EVENT_IN_CHELTENHAM_TUE_THU,OVERRIDDEN_EVENT_IN_BRISTOL_TUE_THU",
+                    "X-UID:EVENT_IN_CHELTENHAM_TUE_THU,OVERRIDDEN_EVENT_IN_BRISTOL_TUE_THU,EVENT_IN_READING_TUE_THU,EVENT_IN_LONDON_TUE_THU",
                     "OR",
                     "(X-UID:ONLINE_EVENT_MON_WED AND X-UID:EVENT_IN_OXFORD_MON_WED)", // Impossible condition - returns nothing because an event cannot have multiple UIDs.
                 ")",
-                "X-LIMIT:50",
+                "X-LIMIT:4",
                 "X-OFFSET:0",
-                "X-DISTINCT:UID",
                 "X-TZID:Europe/Vilnius",
-                "X-ORDER-BY:DTSTART-GEO-DIST;51.55577390;-1.77971760",
+                "X-ORDER-BY:DTSTART-GEO-DIST;51.454481838260214;-2.588329192623361",
             ],
             [
                 [
                     [
                         "DTSTART;TZID=Europe/Vilnius:20210105T203000",
-                        "X-GEO-DIST:43.390803KM",
+                        "X-GEO-DIST:60.692838KM",
                     ],
                     [
                         "CATEGORIES:CATEGORY_FOUR,CATEGORY_ONE",
@@ -1387,22 +1392,56 @@ mod integration {
                 ],
                 [
                     [
-                        "DTSTART;TZID=Europe/Vilnius:20210105T203000",
-                        "X-GEO-DIST:57.088038KM",
+                        "DTSTART;TZID=Europe/Vilnius:20210107T200000",
+                        "X-GEO-DIST:111.491952KM",
                     ],
                     [
-                        "CATEGORIES:CATEGORY_OVERRIDE",
-                        "DTEND;TZID=Europe/Vilnius:20210105T210000",
-                        "DTSTART;TZID=Europe/Vilnius:20210105T203000",
+                        "CATEGORIES:CATEGORY_ONE,CATEGORY_THREE",
+                        "DTEND;TZID=Europe/Vilnius:20210107T203000",
+                        "DTSTART;TZID=Europe/Vilnius:20210107T200000",
                         "DURATION:PT30M",
-                        "GEO:51.454481838260214;-2.588329192623361",
-                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20210105T203000",
-                        "RELATED-TO;RELTYPE=PARENT:PARENT_UID_OVERRIDE",
-                        "SUMMARY:Overridden Event in Bristol on Tuesdays and Thursdays at 6:30PM",
+                        "GEO:51.45442303961853;-0.9792277140273513",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20210107T200000",
+                        "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
+                        "SUMMARY:Event in Reading on Tuesdays and Thursdays at 6:00PM",
+                        "UID:EVENT_IN_READING_TUE_THU",
+                    ],
+                ],
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20210107T203000",
+                        "X-GEO-DIST:60.692838KM",
+                    ],
+                    [
+                        "CATEGORIES:CATEGORY_FOUR,CATEGORY_ONE",
+                        "DTEND;TZID=Europe/Vilnius:20210107T210000",
+                        "DTSTART;TZID=Europe/Vilnius:20210107T203000",
+                        "DURATION:PT30M",
+                        "GEO:51.89936851432488;-2.078357552295971",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20210107T203000",
+                        "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
+                        "SUMMARY:Event in Cheltenham on Tuesdays and Thursdays at 6:30PM",
+                        "UID:EVENT_IN_CHELTENHAM_TUE_THU",
+                    ],
+                ],
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20210107T203000",
+                        "X-GEO-DIST:60.692838KM",
+                    ],
+                    [
+                        "CATEGORIES:CATEGORY_FOUR,CATEGORY_ONE",
+                        "DTEND;TZID=Europe/Vilnius:20210107T210000",
+                        "DTSTART;TZID=Europe/Vilnius:20210107T203000",
+                        "DURATION:PT30M",
+                        "GEO:51.89936851432488;-2.078357552295971",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20210107T203000",
+                        "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
+                        "SUMMARY:Event in Bristol overridden to run in Cheltenham instead",
                         "UID:OVERRIDDEN_EVENT_IN_BRISTOL_TUE_THU",
                     ],
                 ],
-            ],
+            ]
         );
 
         assert_error_returned!(
@@ -2271,6 +2310,10 @@ mod integration {
                             "X-GEO;DIST=105.5KM:51.55577390;-1.77971760",
                             "X-CATEGORIES:CATEGORY_ONE",
                             "X-RELATED-TO;RELTYPE=PARENT:PARENT_UID",
+                            "(",
+                            "X-CATEGORIES:CATEGORY_TWO",
+                            "X-RELATED-TO;RELTYPE=CHILD:CHILD_UID",
+                            ")",
                         ].join(" ").to_string()
                     )
                     .query(connection)


### PR DESCRIPTION
Accommodate blank `GEO` properties to allow overriding events to have no `GEO` coordinates.

An example of this is an event running in the real world but overridden to run online for one session.

@apexatoll 