### PR TITLE
Fix RDCL.evt_query by X-LOCATION-TYPE bug

### DIFF
--- a/redical_core/src/calendar.rs
+++ b/redical_core/src/calendar.rs
@@ -119,6 +119,7 @@ impl Calendar {
 
         let indexed_categories = &mut self.indexed_categories;
         let indexed_related_to = &mut self.indexed_related_to;
+        let indexed_location_type = &mut self.indexed_location_type;
         let indexed_geo = &mut self.indexed_geo;
         let indexed_class = &mut self.indexed_class;
 
@@ -136,6 +137,12 @@ impl Calendar {
             if let Some(indexed_event_related_to) = &event.indexed_related_to {
                 for (indexed_term, indexed_conclusion) in &indexed_event_related_to.terms {
                     indexed_related_to.insert(event_uid.to_owned(), indexed_term.to_owned(), indexed_conclusion)?;
+                }
+            }
+
+            if let Some(indexed_event_location_type) = &event.indexed_location_type {
+                for (indexed_term, indexed_conclusion) in &indexed_event_location_type.terms {
+                    indexed_location_type.insert(event_uid.to_owned(), indexed_term.to_owned(), indexed_conclusion)?;
                 }
             }
 

--- a/redical_core/src/event_instance.rs
+++ b/redical_core/src/event_instance.rs
@@ -332,7 +332,7 @@ impl<'a> EventInstanceIterator<'a> {
     }
 }
 
-impl<'a> Iterator for EventInstanceIterator<'a> {
+impl Iterator for EventInstanceIterator<'_> {
     type Item = EventInstance;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/redical_core/src/event_occurrence_iterator.rs
+++ b/redical_core/src/event_occurrence_iterator.rs
@@ -293,7 +293,7 @@ impl<'a> EventOccurrenceIterator<'a> {
     }
 }
 
-impl<'a> Iterator for EventOccurrenceIterator<'a> {
+impl Iterator for EventOccurrenceIterator<'_> {
     type Item = (i64, i64, Option<EventOccurrenceOverride>);
     fn next(&mut self) -> Option<Self::Item> {
         if self.is_ended {

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -29,7 +29,7 @@ pub struct EventQueryIndexAccessor<'cal> {
     calendar: &'cal Calendar
 }
 
-impl<'cal> EventQueryIndexAccessor<'cal> {
+impl EventQueryIndexAccessor<'_> {
     /// This removes any event UIDs with an `IndexedConclusion::Exclude` value, or if an event UID
     /// has an associated `IndexedConclusion::Include` with exceptions, it will just return
     /// `IndexedConclusion::Include` without any exceptions as we do not care about overrides when

--- a/redical_ical/src/lib.rs
+++ b/redical_ical/src/lib.rs
@@ -14,7 +14,7 @@ pub struct ParserError<'a> {
     context: Vec<String>,
 }
 
-impl <'a> std::fmt::Display for ParserError<'a> {
+impl std::fmt::Display for ParserError<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         write!(f, "{}", convert_error(self.span.into_fragment(), self.to_owned()))
     }
@@ -176,7 +176,7 @@ pub trait UnicodeSegmentation {
     fn wrapped_grapheme_indices(&self, is_extended: bool) -> unicode_segmentation::GraphemeIndices;
 }
 
-impl<'a> UnicodeSegmentation for ParserInput<'a> {
+impl UnicodeSegmentation for ParserInput<'_> {
     #[inline]
     fn wrapped_grapheme_indices(&self, is_extended: bool) -> unicode_segmentation::GraphemeIndices {
         unicode_segmentation::UnicodeSegmentation::grapheme_indices(self.into_fragment(), is_extended)

--- a/redical_ical/src/values/duration.rs
+++ b/redical_ical/src/values/duration.rs
@@ -129,7 +129,6 @@ pub fn dur_hour(input: ParserInput) -> ParserResult<i64> {
 /// Parse dur_minute chars.
 ///
 /// dur-minute = 1*DIGIT "M" [dur-second]
-
 pub fn dur_minute(input: ParserInput) -> ParserResult<i64> {
     map_res(
         terminated(

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1895,34 +1895,34 @@ mod integration {
             ],
         );
 
-        // FIXME: Assert location-type indexes are rebuilt:
-        // query_calendar_and_assert_matching_events!(
-        //     &mut new_connection,
-        //     "TEST_CALENDAR_UID",
-        //     [
-        //         "X-LOCATION-TYPE:HALL",
-        //     ],
-        //     [
-        //         [
-        //             [
-        //                 "DTSTART:20201231T183000Z",
-        //             ],
-        //             [
-        //                 "CATEGORIES:CATEGORY_ONE,CATEGORY_TWO",
-        //                 "CLASS:PUBLIC",
-        //                 "DTEND:20201231T190000Z",
-        //                 "DTSTART:20201231T183000Z",
-        //                 "GEO:51.89936851432488;-2.078357552295971",
-        //                 "LAST-MODIFIED:20210501T090000Z",
-        //                 "LOCATION-TYPE:HALL",
-        //                 "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
-        //                 "RRULE:BYDAY=TH,TU;COUNT=3;FREQ=WEEKLY;INTERVAL=1",
-        //                 "SUMMARY:Event in Cheltenham on Tuesdays and Thursdays at 6:30PM",
-        //                 "UID:EVENT_IN_CHELTENHAM_TUE_THU",
-        //             ],
-        //         ],
-        //     ],
-        // );
+        // Assert location-type indexes are rebuilt:
+        query_calendar_and_assert_matching_events!(
+            &mut new_connection,
+            "TEST_CALENDAR_UID",
+            [
+                "X-LOCATION-TYPE:HALL",
+            ],
+            [
+                [
+                    [
+                        "DTSTART:20201231T183000Z",
+                    ],
+                    [
+                        "CATEGORIES:CATEGORY_ONE,CATEGORY_TWO",
+                        "CLASS:PUBLIC",
+                        "DTEND:20201231T190000Z",
+                        "DTSTART:20201231T183000Z",
+                        "GEO:51.89936851432488;-2.078357552295971",
+                        "LAST-MODIFIED:20210501T090000Z",
+                        "LOCATION-TYPE:HALL",
+                        "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
+                        "RRULE:BYDAY=TH,TU;COUNT=3;FREQ=WEEKLY;INTERVAL=1",
+                        "SUMMARY:Event in Cheltenham on Tuesdays and Thursdays at 6:30PM",
+                        "UID:EVENT_IN_CHELTENHAM_TUE_THU",
+                    ],
+                ],
+            ],
+        );
 
         // Assert class indexes are rebuilt:
         query_calendar_and_assert_matching_events!(


### PR DESCRIPTION
- This was a result of the location indices not being rebuilt following RDB reload.
- Confirmed in tests and then fixed by ensuring these indexes are rebuilt