### PR TITLE
Update prune commands to return Integer

### DIFF
--- a/docs/commands/rdcl.evo_prune.md
+++ b/docs/commands/rdcl.evo_prune.md
@@ -27,7 +27,7 @@ The UID of the desired event stored within the calendar to prune the occurrence 
 
 ## Return value 
 
-`RDCL.EVO_DEL` returns an [integer](https://redis.io/docs/reference/protocol-spec/#integers) representing a boolean, `1` if successful and `0` if not.
+`RDCL.EVO_DEL` returns an [integer](https://redis.io/docs/reference/protocol-spec/#integers) representing the number of pruned event occurrence overrides.
 
 For more information about replies, see [Redis serialization protocol specification](https://redis.io/docs/reference/protocol-spec). 
 

--- a/docs/commands/rdcl.evt_prune.md
+++ b/docs/commands/rdcl.evt_prune.md
@@ -22,7 +22,7 @@ The date-string representing the lower bound (inclusive) range to prune until.
 
 ## Return value
 
-`RDCL.EVT_PRUNE` returns an [integer](https://redis.io/docs/reference/protocol-spec/#integers) representing a boolean, `1` if successful and `0` if not.
+`RDCL.EVT_PRUNE` returns an [integer](https://redis.io/docs/reference/protocol-spec/#integers) representing the number of events pruned.
 
 ## Examples
 

--- a/redical_redis/src/commands/rdcl_evt_prune.rs
+++ b/redical_redis/src/commands/rdcl_evt_prune.rs
@@ -59,7 +59,7 @@ pub fn redical_event_prune(ctx: &Context, args: Vec<RedisString>) -> RedisResult
         )?;
     }
 
-    Ok(RedisValue::Bool(true))
+    Ok(RedisValue::Integer(pruned_events.len() as i64))
 }
 
 // TODO: make this a helper

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -750,7 +750,15 @@ mod integration {
         }
 
         // Test pruning a specific event on a calendar
-        prune_event_overrides!(connection, "TEST_CALENDAR_UID", "EVENT_ONE", "20200105T000000Z", "20200110T160000Z");
+        let pruned_override_count: i64 = prune_event_overrides!(
+            connection,
+            "TEST_CALENDAR_UID",
+            "EVENT_ONE",
+            "20200105T000000Z",
+            "20200110T160000Z",
+        );
+
+        assert_eq!(pruned_override_count, 3);
 
         list_and_assert_matching_event_overrides!(
             connection,
@@ -765,7 +773,14 @@ mod integration {
         );
 
         // Test pruning some overrides on all events on a calendar
-        prune_event_overrides!(connection, "TEST_CALENDAR_UID", "20200101T000000Z", "20200108T160000Z");
+        let pruned_override_count: i64 = prune_event_overrides!(
+            connection,
+            "TEST_CALENDAR_UID",
+            "20200101T000000Z",
+            "20200108T160000Z",
+        );
+
+        assert_eq!(pruned_override_count, 8);
 
         list_and_assert_matching_event_overrides!(
             connection,
@@ -788,7 +803,14 @@ mod integration {
 
         // Test pruning all remaining overrides on all events on a calendar (and all associated keyspace events).
         listen_for_keyspace_events(6480, |message_queue: &mut Arc<Mutex<VecDeque<redis::Msg>>>| {
-            prune_event_overrides!(connection, "TEST_CALENDAR_UID", "20200101T000000Z", "20210101T000000Z");
+            let pruned_override_count: i64 = prune_event_overrides!(
+                connection,
+                "TEST_CALENDAR_UID",
+                "20200101T000000Z",
+                "20210101T000000Z",
+            );
+
+            assert_eq!(pruned_override_count, 3);
 
             list_and_assert_matching_event_overrides!(connection, "TEST_CALENDAR_UID", "EVENT_ONE", []);
             list_and_assert_matching_event_overrides!(connection, "TEST_CALENDAR_UID", "EVENT_TWO", []);

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -349,7 +349,9 @@ mod integration {
         );
 
         listen_for_keyspace_events(6480, |message_queue: &mut Arc<Mutex<VecDeque<redis::Msg>>>| {
-            prune_events!(connection, "TEST_CALENDAR_UID", from, until);
+            let number_pruned: i64 = prune_events!(connection, "TEST_CALENDAR_UID", from, until);
+
+            assert_eq!(number_pruned, 2);
 
             assert_keyspace_events_published!(
                 message_queue,

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -155,26 +155,22 @@ macro_rules! prune_events {
 #[macro_export]
 macro_rules! prune_event_overrides {
     ($connection:expr, $calendar_uid:expr, $from_date_string:expr, $until_date_string:expr $(,)*) => {
-        let calendar_index_rebuild_result =
-            redis::cmd("rdcl.evo_prune")
+        redis::cmd("rdcl.evo_prune")
             .arg($calendar_uid)
             .arg($from_date_string)
             .arg($until_date_string)
-            .query($connection);
-
-        assert_eq!(calendar_index_rebuild_result, RedisResult::Ok(true));
+            .query($connection)
+            .unwrap()
     };
 
     ($connection:expr, $calendar_uid:expr, $event_uid:expr, $from_date_string:expr, $until_date_string:expr $(,)*) => {
-        let calendar_index_rebuild_result =
-            redis::cmd("rdcl.evo_prune")
+        redis::cmd("rdcl.evo_prune")
             .arg($calendar_uid)
             .arg($event_uid)
             .arg($from_date_string)
             .arg($until_date_string)
-            .query($connection);
-
-        assert_eq!(calendar_index_rebuild_result, RedisResult::Ok(true));
+            .query($connection)
+            .unwrap()
     };
 }
 

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -143,14 +143,12 @@ macro_rules! rebuild_calendar_indexes {
 #[macro_export]
 macro_rules! prune_events {
     ($connection:expr, $calendar_uid:expr, $from_date_string:expr, $until_date_string:expr $(,)*) => {
-        let calendar_event_prune_result =
-            redis::cmd("rdcl.evt_prune")
+        redis::cmd("rdcl.evt_prune")
             .arg($calendar_uid)
             .arg($from_date_string)
             .arg($until_date_string)
-            .query($connection);
-
-        assert_eq!(calendar_event_prune_result, RedisResult::Ok(true));
+            .query($connection)
+            .unwrap()
     };
 }
 


### PR DESCRIPTION
- This PR updates the `EVO_PRUNE` and `EVT_PRUNE` commands to return an Integer of the number of entities removed as part of the command process
- This is to improve observability and monitoring of the prune commands and to give an indication of the amount of work each command has done
