### PR TITLE
Ensure that EVT_PRUNE replicates work on all instances

### DIFF
--- a/redical_redis/src/commands/rdcl_evt_prune.rs
+++ b/redical_redis/src/commands/rdcl_evt_prune.rs
@@ -47,6 +47,11 @@ pub fn redical_event_prune(ctx: &Context, args: Vec<RedisString>) -> RedisResult
         until.to_string(),
     )?;
 
+    // Use this command when replicating across other Redis instances.
+    // We call this here to ensure all replicas begin at and reach the same point if any errors
+    // are raised in the following prune process.
+    ctx.replicate_verbatim();
+
     let pruned_events = prune_and_reindex(calendar, from_timestamp, until_timestamp)?;
 
     for (event_uid, _) in pruned_events.iter() {


### PR DESCRIPTION
- This was missed in the implementation of `EVT_PRUNE`
