### PR TITLE
Implement negative querying 1

### DIFF
--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -126,6 +126,14 @@ impl InvertedCalendarIndexTerm {
         }
     }
 
+    pub fn inverse(&self) -> Self {
+        let inverted_events = self.events.iter()
+            .map(|(uid, indexed_conclusion)| (uid.clone(), indexed_conclusion.negate()))
+            .collect();
+
+        Self::new_with_events(inverted_events)
+    }
+
     pub fn include_event_occurrence(&self, event_uid: String, occurrence: i64) -> bool {
         match self.events.get(&event_uid) {
             Some(indexed_conclusion) => indexed_conclusion.include_event_occurrence(occurrence),
@@ -1082,6 +1090,32 @@ mod test {
                     ),
                 ]),
             },
+        );
+    }
+
+    #[test]
+    fn test_inverted_index_term_inverse() {
+        let events = vec![
+            (String::from("Event one"), IndexedConclusion::Include(None)),
+            (String::from("Event two"), IndexedConclusion::Include(Some(HashSet::from([100])))),
+            (String::from("Event three"), IndexedConclusion::Exclude(None)),
+            (String::from("Event four"), IndexedConclusion::Exclude(Some(HashSet::from([100])))),
+        ];
+
+        let inverted_index_term = InvertedCalendarIndexTerm::new_with_events(events);
+
+        assert_eq!(
+            inverted_index_term.inverse(),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from(
+                    [
+                        (String::from("Event one"), IndexedConclusion::Exclude(None)),
+                        (String::from("Event two"), IndexedConclusion::Exclude(Some(HashSet::from([100])))),
+                        (String::from("Event three"), IndexedConclusion::Include(None)),
+                        (String::from("Event four"), IndexedConclusion::Include(Some(HashSet::from([100])))),
+                    ]
+                )
+            }
         );
     }
 

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -744,6 +744,14 @@ impl IndexedConclusion {
         }
     }
 
+    // Flips the polarity of an IndexedConclusion whilst maintaining exceptions.
+    pub fn negate(&self) -> Self {
+        match self {
+            Self::Include(exceptions) => Self::Exclude(exceptions.clone()),
+            Self::Exclude(exceptions) => Self::Include(exceptions.clone()),
+        }
+    }
+
     pub fn min_max_exceptions(&self) -> Option<(i64, i64)> {
         let exceptions = match self {
             IndexedConclusion::Include(exceptions) => exceptions,
@@ -1208,6 +1216,29 @@ mod test {
                 &IndexedConclusion::Include(None)
             ),
             IndexedConclusion::Include(None)
+        );
+    }
+
+    #[test]
+    fn test_indexed_conclusion_negate() {
+        assert_eq!(
+            IndexedConclusion::Include(None).negate(),
+            IndexedConclusion::Exclude(None)
+        );
+
+        assert_eq!(
+            IndexedConclusion::Include(Some(HashSet::from([100, 200]))).negate(),
+            IndexedConclusion::Exclude(Some(HashSet::from([100, 200]))),
+        );
+
+        assert_eq!(
+            IndexedConclusion::Exclude(None).negate(),
+            IndexedConclusion::Include(None)
+        );
+
+        assert_eq!(
+            IndexedConclusion::Exclude(Some(HashSet::from([100, 200]))).negate(),
+            IndexedConclusion::Include(Some(HashSet::from([100, 200]))),
         );
     }
 

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -487,28 +487,6 @@ where
 
         Ok(self)
     }
-
-    // pub fn insert_all_event(&mut self, event: Event) -> Result<&mut Self, String> {
-    //     if event.indexed_categories.is_none() {
-    //         return Ok(self);
-    //     }
-
-    //     let Some(indexed_categories) = event.indexed_categories;
-
-    //     for (category, indexed_conclusion) in indexed_categories.categories.iter() {
-    //         move || {
-    //             self.terms.entry(*category).and_modify(|inverted_index_term| {
-    //                 inverted_index_term.events.insert(event.uid, *indexed_conclusion);
-    //             }).or_insert(
-    //                          InvertedCalendarIndexTerm {
-    //                     events: HashMap::from([ (event.uid, *indexed_conclusion) ])
-    //                 }
-    //             );
-    //         };
-    //     }
-
-    //     Ok(self)
-    // }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -496,33 +496,31 @@ where
         Ok(self)
     }
 
-    // Returns an Event set that match the given indexed term.
+    /// Returns an Event set that match the given indexed term.
     pub fn get_term(&self, term: &K) -> Option<&InvertedCalendarIndexTerm> {
         self.terms.get(term)
     }
 
-    // Returns an Event set that does not match the given indexed term. This is acheived by first
-    // finding the event set for the given term, inverting the conclusions and then merging this
-    // with the other term event sets in an additive manner.
-    //
-    // This is required because a terms event set may not contain all events in the calendar if
-    // they are not indexed to the given term to exclude.
-    pub fn get_not_term(&self, term: &K) -> InvertedCalendarIndexTerm {
-        let mut inverse_term_index = match self.get_term(term) {
-            Some(term_index) => term_index.inverse(),
-            None => InvertedCalendarIndexTerm::new(),
-        };
+    pub fn get_not_term(&self, term: &K, calendar_event_uids: &Vec<String>) -> InvertedCalendarIndexTerm {
+        let mut calendar_index_term = InvertedCalendarIndexTerm::default();
 
-        for (other_term, index) in self.terms.iter() {
-            if other_term == term { continue }
-
-            inverse_term_index = InvertedCalendarIndexTerm::merge_or(
-                &inverse_term_index,
-                index,
-            );
+        for event_uid in calendar_event_uids.into_iter() {
+            calendar_index_term.insert_included_event(event_uid.to_owned(), None);
         }
 
-        inverse_term_index
+        if let Some(matching_term_index) = self.get_term(term) {
+            let inverse_matching_term_index = matching_term_index.inverse();
+
+            for (event_uid, indexed_conclusion) in inverse_matching_term_index.events {
+                if indexed_conclusion.is_empty_exclude() {
+                    calendar_index_term.events.remove(&event_uid);
+                } else {
+                    calendar_index_term.events.insert(event_uid, indexed_conclusion);
+                }
+            }
+        }
+
+        calendar_index_term
     }
 }
 
@@ -913,6 +911,16 @@ mod test {
 
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
+    fn example_calendar_event_uids() -> Vec<String> {
+        example_calendar_index()
+            .terms
+            .values()
+            .map(|event_set| event_set.events.keys())
+            .flatten()
+            .cloned()
+            .collect::<Vec<String>>()
+    }
+
     fn example_calendar_index() -> InvertedCalendarIndex<String> {
         let online_events = InvertedCalendarIndexTerm {
             events: HashMap::from([
@@ -994,12 +1002,13 @@ mod test {
     #[test]
     fn test_inverted_calendar_index_get_not_term() {
         let index = example_calendar_index();
+        let event_uids = example_calendar_event_uids();
 
         // With a term that is indexed.
         let term = String::from("ONLINE");
 
         assert_eq!(
-            index.get_not_term(&term),
+            index.get_not_term(&term, &event_uids),
             InvertedCalendarIndexTerm {
                 events: HashMap::from([
                     (
@@ -1027,7 +1036,7 @@ mod test {
         let term = String::from("FOOBAR");
 
         assert_eq!(
-            index.get_not_term(&term),
+            index.get_not_term(&term, &event_uids),
             InvertedCalendarIndexTerm {
                 events: HashMap::from([
                     (

--- a/redical_core/src/queries/event_instance_query.rs
+++ b/redical_core/src/queries/event_instance_query.rs
@@ -83,6 +83,30 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }
+
+    fn inverse_search_uid_index(&self, _uid: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_location_type_index(&self, _location_type: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_categories_index(&self, _category: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_related_to_index(&self, _reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_geo_index(&self, _distance: &GeoDistance, _long_lat: &GeoPoint) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_class_index(&self, _class: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
 }
 
 /// This struct implements all the query logic specific to querying all the event instances on a

--- a/redical_core/src/queries/event_instance_query.rs
+++ b/redical_core/src/queries/event_instance_query.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use chrono_tz::Tz;
@@ -84,28 +85,46 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
             .to_owned()
     }
 
-    fn inverse_search_uid_index(&self, _uid: &str) -> InvertedCalendarIndexTerm {
+    fn inverse_search_uid_index(&self, uid: &str) -> InvertedCalendarIndexTerm {
+        let mut event_uids = self.calendar.events.keys().cloned().collect::<Vec<_>>();
+
+        event_uids.retain(|event_uid| event_uid != uid);
+
+        InvertedCalendarIndexTerm {
+            events: HashMap::from_iter(
+                event_uids.into_iter().map(|event_uid| 
+                    (event_uid, IndexedConclusion::Include(None)),
+                )
+            ),
+        }
+    }
+
+    fn inverse_search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
+        self.calendar
+            .indexed_location_type
+            .get_not_term(&location_type.to_string())
+    }
+
+    fn inverse_search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
+        self.calendar
+            .indexed_categories
+            .get_not_term(&category.to_string())
+    }
+
+    fn inverse_search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
+        self.calendar
+            .indexed_related_to
+            .get_not_term(reltype_uids)
+    }
+
+    fn inverse_search_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm {
         todo!();
     }
 
-    fn inverse_search_location_type_index(&self, _location_type: &str) -> InvertedCalendarIndexTerm {
-        todo!();
-    }
-
-    fn inverse_search_categories_index(&self, _category: &str) -> InvertedCalendarIndexTerm {
-        todo!();
-    }
-
-    fn inverse_search_related_to_index(&self, _reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
-        todo!();
-    }
-
-    fn inverse_search_geo_index(&self, _distance: &GeoDistance, _long_lat: &GeoPoint) -> InvertedCalendarIndexTerm {
-        todo!();
-    }
-
-    fn inverse_search_class_index(&self, _class: &str) -> InvertedCalendarIndexTerm {
-        todo!();
+    fn inverse_search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
+        self.calendar
+            .indexed_class
+            .get_not_term(&class.to_string())
     }
 }
 
@@ -499,6 +518,29 @@ mod test {
                 ]),
             }
         );
+
+        // Negative matching: term exists
+        assert_eq!(
+            accessor.inverse_search_uid_index("EVENT_ONE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_TWO"), IndexedConclusion::Include(None)),
+                    (String::from("EVENT_THREE"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Negative matching: term does not exist
+        assert_eq!(
+            accessor.inverse_search_uid_index("EVENT_FOUR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_ONE"), IndexedConclusion::Include(None)),
+                    (String::from("EVENT_TWO"), IndexedConclusion::Include(None)),
+                    (String::from("EVENT_THREE"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
     }
 
     #[test]
@@ -567,6 +609,46 @@ mod test {
                 events: HashMap::new(),
             }
         );
+
+        // Negative matching: term exists
+        // - Matching term: all conclusions inverted, events where all included removed
+        // - Non matching terms all maintained (except Exclude(None))
+        assert_eq!(
+            accessor.inverse_search_location_type_index("IN-PERSON"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not online"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("Mostly in person"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("Not in person"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly not in person"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("All variable"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly variable"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not variable"), IndexedConclusion::Exclude(Some([100].into()))),
+                ])
+            }
+        );
+
+        // Negative matching: term does not exist
+        // - All event sets merged
+        // - Exclude(None) removed
+        assert_eq!(
+            accessor.inverse_search_location_type_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not online"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All in person"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in person"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not in person"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All variable"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly variable"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not variable"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]),
+            }
+        );
     }
 
     #[test]
@@ -633,6 +715,46 @@ mod test {
             accessor.search_categories_index("FOOBAR"),
             InvertedCalendarIndexTerm {
                 events: HashMap::new(),
+            }
+        );
+
+        // Negative matching: term exists
+        // - Matching term: all conclusions inverted, events where all included removed
+        // - Non matching terms all maintained (except Exclude(None))
+        assert_eq!(
+            accessor.inverse_search_categories_index("Sports"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All A&C"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly A&C"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not A&C"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All yoga"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly yoga"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not yoga"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("Mostly sports"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("Not sports"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly not sports"), IndexedConclusion::Include(Some([100].into()))),
+                ])
+            }
+        );
+
+        // Negative matching: term does not exist
+        // - All event sets merged
+        // - Exclude(None) removed
+        assert_eq!(
+            accessor.inverse_search_categories_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All A&C"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly A&C"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not A&C"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All yoga"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly yoga"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not yoga"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All sports"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly sports"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not sports"), IndexedConclusion::Exclude(Some([100].into()))),
+                ])
             }
         );
     }
@@ -722,6 +844,56 @@ mod test {
                 events: HashMap::new(),
             }
         );
+
+        // Negative matching: term exists
+        // - Matching term: all conclusions inverted, events where all included removed
+        // - Non matching terms all maintained (except Exclude(None))
+        assert_eq!(
+            accessor.inverse_search_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-1"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("Mostly account-1"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("Not account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly not account-1"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("All account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-2"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not account-2"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All account-3"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-3"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not account-3"), IndexedConclusion::Exclude(Some([100].into()))),
+                ])
+            }
+        );
+
+        // Negative matching: term does not exist
+        // - All event sets merged
+        // - Exclude(None) removed
+        assert_eq!(
+            accessor.inverse_search_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-4"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-1"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not account-1"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-2"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not account-2"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All account-3"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-3"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not account-3"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]),
+            }
+        );
     }
 
     #[test]
@@ -796,6 +968,8 @@ mod test {
                 events: HashMap::new(),
             }
         );
+
+        todo!();
     }
 
     #[test]
@@ -862,6 +1036,46 @@ mod test {
             accessor.search_class_index("FOOBAR"),
             InvertedCalendarIndexTerm {
                 events: HashMap::new(),
+            }
+        );
+
+        // Negative matching: term exists
+        // - Matching term: all conclusions inverted, events where all included removed
+        // - Non matching terms all maintained (except Exclude(None))
+        assert_eq!(
+            accessor.inverse_search_class_index("PUBLIC"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("Mostly public"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("Not public"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly not public"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not private"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All unavailable"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly unavailable"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not unavailable"), IndexedConclusion::Exclude(Some([100].into()))),
+                ])
+            }
+        );
+
+        // Negative matching: term does not exist
+        // - All event sets merged
+        // - Exclude(None) removed
+        assert_eq!(
+            accessor.inverse_search_class_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All public"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly public"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not public"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not private"), IndexedConclusion::Exclude(Some([100].into()))),
+                    (String::from("All unavailable"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly unavailable"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly not unavailable"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]),
             }
         );
     }

--- a/redical_core/src/queries/event_instance_query.rs
+++ b/redical_core/src/queries/event_instance_query.rs
@@ -49,8 +49,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
         self.calendar
             .indexed_location_type
-            .terms
-            .get(location_type)
+            .get_term(&location_type.to_string())
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }
@@ -58,8 +57,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
         self.calendar
             .indexed_categories
-            .terms
-            .get(category)
+            .get_term(&category.to_string())
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }
@@ -67,8 +65,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
         self.calendar
             .indexed_related_to
-            .terms
-            .get(reltype_uids)
+            .get_term(reltype_uids)
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }
@@ -82,8 +79,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
         self.calendar
             .indexed_class
-            .terms
-            .get(class)
+            .get_term(&class.to_string())
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -66,19 +66,19 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
 
     fn search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_location_type.terms.get(location_type)
+            self.calendar.indexed_location_type.get_term(&location_type.to_string())
         )
     }
 
     fn search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_categories.terms.get(category)
+            self.calendar.indexed_categories.get_term(&category.to_string())
         )
     }
 
     fn search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_related_to.terms.get(reltype_uids)
+            self.calendar.indexed_related_to.get_term(reltype_uids)
         )
     }
 
@@ -92,7 +92,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
 
     fn search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_class.terms.get(class)
+            self.calendar.indexed_class.get_term(&class.to_string())
         )
     }
 }

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -468,7 +468,415 @@ mod test {
     use crate::{GeoPoint, KeyValuePair};
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
-    use std::collections::HashSet;
+    use std::collections::{HashSet, HashMap};
+
+    #[test]
+    fn test_uid_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let event_one = Event::parse_ical("EVENT_ONE", "").unwrap();
+        let event_two = Event::parse_ical("EVENT_TWO", "").unwrap();
+        let event_three = Event::parse_ical("EVENT_THREE", "").unwrap();
+
+        calendar.insert_event(event_one);
+        calendar.insert_event(event_two);
+        calendar.insert_event(event_three);
+        calendar.rebuild_indexes().unwrap();
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_uid_index("EVENT_ONE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_ONE"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // TODO: Shouldn't this return an empty event set?
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_uid_index("EVENT_FOUR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_FOUR"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+    }
+
+    #[test]
+    fn test_location_type_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_location_types = [
+            (
+                String::from("ONLINE"),
+                [
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not online"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not online"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("IN-PERSON"),
+                [
+                    (String::from("All in person"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in person"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not in person"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not in person"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("VARIABLE"),
+                [
+                    (String::from("All variable"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly variable"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not variable"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not variable"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            )
+        ];
+
+        for (location_type, events) in indexed_location_types.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_location_type.insert(
+                    event_uid.to_string(),
+                    location_type.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        // - Only Includes kept
+        // - Instance exceptions removed
+        assert_eq!(
+            accessor.search_location_type_index("ONLINE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        // - Empty event set
+        assert_eq!(
+            accessor.search_location_type_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_categories_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_categories = [
+            (
+                String::from("Arts and Crafts"),
+                [
+                    (String::from("All A&C"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly A&C"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not A&C"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not A&C"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("Yoga"),
+                [
+                    (String::from("All yoga"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly yoga"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not yoga"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not yoga"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("Sports"),
+                [
+                    (String::from("All sports"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly sports"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not sports"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not sports"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            )
+        ];
+
+        for (category, events) in indexed_categories.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_categories.insert(
+                    event_uid.to_string(),
+                    category.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        // - Only Includes kept
+        // - Instance exceptions removed
+        assert_eq!(
+            accessor.search_categories_index("Sports"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All sports"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly sports"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        // - Empty event set
+        assert_eq!(
+            accessor.search_categories_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_related_to_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_related_to = [
+            (
+                KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-1"),
+                ),
+                [
+                    (String::from("All account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-1"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not account-1"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not account-1"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-2"),
+                ),
+                [
+                    (String::from("All account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-2"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not account-2"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not account-2"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-3"),
+                ),
+                [
+                    (String::from("All account-3"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-3"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not account-3"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not account-3"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            )
+        ];
+
+        for (related_to, events) in indexed_related_to.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_related_to.insert(
+                    event_uid.to_string(),
+                    related_to.clone(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        // - Only Includes kept
+        // - Instance exceptions removed
+        assert_eq!(
+            accessor.search_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-1"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-1"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        // - Empty event set
+        assert_eq!(
+            accessor.search_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-4"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_geo_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let new_york = GeoPoint::new(40.7128_f64, -74.006_f64);
+        let london = GeoPoint::new(51.5074_f64, -0.1278_f64);
+        let oxford = GeoPoint::new(51.8773_f64, -1.2475878_f64);
+        let tokyo = GeoPoint::new(24.34478, 124.15717);
+
+        let indexed_geo = [
+            (
+                new_york.clone(),
+                [
+                    (String::from("All in New York"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in New York"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not in New York"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not in New York"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                london.clone(),
+                [
+                    (String::from("All in London"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in London"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not in London"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not London"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                oxford.clone(),
+                [
+                    (String::from("All in Oxford"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not in Oxford"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not in Oxford"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            )
+        ];
+
+        for (geo_point, events) in indexed_geo.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_geo.insert(
+                    event_uid.to_string(),
+                    geo_point,
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        let one_km = GeoDistance::new_from_kilometers_float(1.0_f64);
+
+        // Positive matching: indexed terms in given distance from given point.
+        // - Only Includes kept
+        // - Instance exceptions removed
+        assert_eq!(
+            accessor.search_geo_index(&one_km, &oxford),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All in Oxford"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: no indexed terms in given distance from given point.
+        // - Empty event set
+        assert_eq!(
+            accessor.search_geo_index(&one_km, &tokyo),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_class_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_class = [
+            (
+                String::from("PUBLIC"),
+                [
+                    (String::from("All public"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly public"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not public"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not public"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("PRIVATE"),
+                [
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not private"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not private"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("UNAVAILABLE"),
+                [
+                    (String::from("All unavailable"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly unavailable"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Not unavailable"), IndexedConclusion::Exclude(None)),
+                    (String::from("Mostly not unavailable"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            )
+        ];
+
+        for (class, events) in indexed_class.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_class.insert(
+                    event_uid.to_string(),
+                    class.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        // - Only Includes kept
+        // - Instance exceptions removed
+        assert_eq!(
+            accessor.search_class_index("PRIVATE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        // - Empty event set
+        assert_eq!(
+            accessor.search_class_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
 
     #[test]
     fn test_event_query_index_accessor() {

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -112,9 +112,11 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
     }
 
     fn inverse_search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
+        let event_uids = self.calendar.events.keys().cloned().collect::<Vec<_>>();
+
         let inverse_matches = self.calendar
             .indexed_location_type
-            .get_not_term(&location_type.to_string());
+            .get_not_term(&location_type.to_string(), &event_uids);
 
         Self::included_conclusions_or_nothing(
             Some(&inverse_matches)
@@ -122,9 +124,11 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
     }
 
     fn inverse_search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
+        let event_uids = self.calendar.events.keys().cloned().collect::<Vec<_>>();
+
         let inverse_matches = self.calendar
             .indexed_categories
-            .get_not_term(&category.to_string());
+            .get_not_term(&category.to_string(), &event_uids);
 
         Self::included_conclusions_or_nothing(
             Some(&inverse_matches)
@@ -132,9 +136,11 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
     }
 
     fn inverse_search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
+        let event_uids = self.calendar.events.keys().cloned().collect::<Vec<_>>();
+
         let inverse_matches = self.calendar
             .indexed_related_to
-            .get_not_term(reltype_uids);
+            .get_not_term(reltype_uids, &event_uids);
 
         Self::included_conclusions_or_nothing(
             Some(&inverse_matches)
@@ -142,13 +148,17 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
     }
 
     fn inverse_search_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm {
+        let event_uids = self.calendar.events.keys().cloned().collect::<Vec<_>>();
+
         todo!();
     }
 
     fn inverse_search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
+        let event_uids = self.calendar.events.keys().cloned().collect::<Vec<_>>();
+
         let inverse_matches = self.calendar
             .indexed_class
-            .get_not_term(&class.to_string());
+            .get_not_term(&class.to_string(), &event_uids);
 
         Self::included_conclusions_or_nothing(
             Some(&inverse_matches)

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -95,6 +95,30 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
             self.calendar.indexed_class.get_term(&class.to_string())
         )
     }
+
+    fn inverse_search_uid_index(&self, _uid: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_location_type_index(&self, _location_type: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_categories_index(&self, _category: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_related_to_index(&self, _reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_geo_index(&self, _distance: &GeoDistance, _long_lat: &GeoPoint) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn inverse_search_class_index(&self, _class: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
 }
 
 /// This struct implements all the query logic specific to querying events on a calendar (not the

--- a/redical_core/src/queries/query.rs
+++ b/redical_core/src/queries/query.rs
@@ -28,12 +28,22 @@ use crate::queries::indexed_property_filters::{
 /// exceptions.
 pub trait QueryIndexAccessor<'cal> {
     fn new(calendar: &'cal Calendar) -> Self;
+
+    // Positive matching
     fn search_uid_index(&self, uid: &str) -> InvertedCalendarIndexTerm;
     fn search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm;
     fn search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm;
     fn search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm;
     fn search_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm;
     fn search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm;
+
+    // Negative (not) matching
+    fn inverse_search_uid_index(&self, uid: &str) -> InvertedCalendarIndexTerm;
+    fn inverse_search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm;
+    fn inverse_search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm;
+    fn inverse_search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm;
+    fn inverse_search_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm;
+    fn inverse_search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm;
 }
 
 /// The purpose of this trait is to allow it's implementers to specify the query logic specific to


### PR DESCRIPTION
- This PR is the first part in a series to implement negative querying via the `NOT` operator
