### PR TITLE
Implement negative index lookup

### DIFF
--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -126,6 +126,14 @@ impl InvertedCalendarIndexTerm {
         }
     }
 
+    pub fn inverse(&self) -> Self {
+        let inverted_events = self.events.iter()
+            .map(|(uid, indexed_conclusion)| (uid.clone(), indexed_conclusion.negate()))
+            .collect();
+
+        Self::new_with_events(inverted_events)
+    }
+
     pub fn include_event_occurrence(&self, event_uid: String, occurrence: i64) -> bool {
         match self.events.get(&event_uid) {
             Some(indexed_conclusion) => indexed_conclusion.include_event_occurrence(occurrence),
@@ -1082,6 +1090,32 @@ mod test {
                     ),
                 ]),
             },
+        );
+    }
+
+    #[test]
+    fn test_inverted_index_term_inverse() {
+        let events = vec![
+            (String::from("Event one"), IndexedConclusion::Include(None)),
+            (String::from("Event two"), IndexedConclusion::Include(Some(HashSet::from([100])))),
+            (String::from("Event three"), IndexedConclusion::Exclude(None)),
+            (String::from("Event four"), IndexedConclusion::Exclude(Some(HashSet::from([100])))),
+        ];
+
+        let inverted_index_term = InvertedCalendarIndexTerm::new_with_events(events);
+
+        assert_eq!(
+            inverted_index_term.inverse(),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from(
+                    [
+                        (String::from("Event one"), IndexedConclusion::Exclude(None)),
+                        (String::from("Event two"), IndexedConclusion::Exclude(Some(HashSet::from([100])))),
+                        (String::from("Event three"), IndexedConclusion::Include(None)),
+                        (String::from("Event four"), IndexedConclusion::Include(Some(HashSet::from([100])))),
+                    ]
+                )
+            }
         );
     }
 

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -744,6 +744,14 @@ impl IndexedConclusion {
         }
     }
 
+    // Flips the polarity of an IndexedConclusion whilst maintaining exceptions.
+    pub fn negate(&self) -> Self {
+        match self {
+            Self::Include(exceptions) => Self::Exclude(exceptions.clone()),
+            Self::Exclude(exceptions) => Self::Include(exceptions.clone()),
+        }
+    }
+
     pub fn min_max_exceptions(&self) -> Option<(i64, i64)> {
         let exceptions = match self {
             IndexedConclusion::Include(exceptions) => exceptions,
@@ -1208,6 +1216,29 @@ mod test {
                 &IndexedConclusion::Include(None)
             ),
             IndexedConclusion::Include(None)
+        );
+    }
+
+    #[test]
+    fn test_indexed_conclusion_negate() {
+        assert_eq!(
+            IndexedConclusion::Include(None).negate(),
+            IndexedConclusion::Exclude(None)
+        );
+
+        assert_eq!(
+            IndexedConclusion::Include(Some(HashSet::from([100, 200]))).negate(),
+            IndexedConclusion::Exclude(Some(HashSet::from([100, 200]))),
+        );
+
+        assert_eq!(
+            IndexedConclusion::Exclude(None).negate(),
+            IndexedConclusion::Include(None)
+        );
+
+        assert_eq!(
+            IndexedConclusion::Exclude(Some(HashSet::from([100, 200]))).negate(),
+            IndexedConclusion::Include(Some(HashSet::from([100, 200]))),
         );
     }
 

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -487,28 +487,6 @@ where
 
         Ok(self)
     }
-
-    // pub fn insert_all_event(&mut self, event: Event) -> Result<&mut Self, String> {
-    //     if event.indexed_categories.is_none() {
-    //         return Ok(self);
-    //     }
-
-    //     let Some(indexed_categories) = event.indexed_categories;
-
-    //     for (category, indexed_conclusion) in indexed_categories.categories.iter() {
-    //         move || {
-    //             self.terms.entry(*category).and_modify(|inverted_index_term| {
-    //                 inverted_index_term.events.insert(event.uid, *indexed_conclusion);
-    //             }).or_insert(
-    //                          InvertedCalendarIndexTerm {
-    //                     events: HashMap::from([ (event.uid, *indexed_conclusion) ])
-    //                 }
-    //             );
-    //         };
-    //     }
-
-    //     Ok(self)
-    // }
 }
 
 #[derive(Debug, Eq, PartialEq, Clone)]

--- a/redical_core/src/inverted_index.rs
+++ b/redical_core/src/inverted_index.rs
@@ -513,7 +513,7 @@ where
     pub fn get_not_term(
         &self,
         term: &K,
-        calendar_event_uids: &Vec<String>
+        calendar_event_uids: &[String]
     ) -> InvertedCalendarIndexTerm {
         // Create an empty event set
         let mut negated_event_set = InvertedCalendarIndexTerm::new();

--- a/redical_core/src/queries/event_instance_query.rs
+++ b/redical_core/src/queries/event_instance_query.rs
@@ -49,8 +49,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
         self.calendar
             .indexed_location_type
-            .terms
-            .get(location_type)
+            .get_term(&location_type.to_string())
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }
@@ -58,8 +57,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
         self.calendar
             .indexed_categories
-            .terms
-            .get(category)
+            .get_term(&category.to_string())
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }
@@ -67,8 +65,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
         self.calendar
             .indexed_related_to
-            .terms
-            .get(reltype_uids)
+            .get_term(reltype_uids)
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }
@@ -82,8 +79,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
         self.calendar
             .indexed_class
-            .terms
-            .get(class)
+            .get_term(&class.to_string())
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -66,19 +66,19 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
 
     fn search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_location_type.terms.get(location_type)
+            self.calendar.indexed_location_type.get_term(&location_type.to_string())
         )
     }
 
     fn search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_categories.terms.get(category)
+            self.calendar.indexed_categories.get_term(&category.to_string())
         )
     }
 
     fn search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_related_to.terms.get(reltype_uids)
+            self.calendar.indexed_related_to.get_term(&reltype_uids)
         )
     }
 
@@ -92,7 +92,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
 
     fn search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_class.terms.get(class)
+            self.calendar.indexed_class.get_term(&class.to_string())
         )
     }
 }

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -78,7 +78,7 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
 
     fn search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
         Self::included_conclusions_or_nothing(
-            self.calendar.indexed_related_to.get_term(&reltype_uids)
+            self.calendar.indexed_related_to.get_term(reltype_uids)
         )
     }
 


### PR DESCRIPTION
- This PR implements `InvertedCalendarIndex.get_term` and `InvertedCalendarIndex.get_not_term`
- `get_term` is a wrapper around the `HashMap` lookup but adds a layer of indirection to allow tighter boundaries and to indicate it has the opposite action to `get_not_term`
- `get_not_term` is a method that allows lookup of event sets that do NOT match a given term
- This is acheived by first building a blanket-included event set of all events in the calendar and subsequently merging in the opposite (inverse) event set from the matching term if it exists
- The `QueryIndexAccessor` trait implementations have been updated to use `get_term`
- A follow up PR will implement the negative matching interface to the `QueryIndexAccessor` traits to move closer to negative querying
