### PR TITLE
Implement QueryIndexAccessor negative matching interface

### DIFF
--- a/redical_core/src/geo_index.rs
+++ b/redical_core/src/geo_index.rs
@@ -395,12 +395,16 @@ mod test {
 
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
+    const RANDOM: GeoPoint = GeoPoint { lat: 51.7854972_f64, long: -1.4701705_f64 };
+    const RANDOM_PLUS_OFFSET: GeoPoint = GeoPoint { lat: 51.785341_f64, long: -1.470240_f64 };
+    const NEW_YORK_CITY: GeoPoint = GeoPoint { lat: 40.7128_f64, long: -74.006_f64 };
+    const CHURCHDOWN: GeoPoint = GeoPoint { lat: 51.8773_f64, long: -2.1686_f64 };
+    const LONDON: GeoPoint = GeoPoint { lat: 51.5074_f64, long: -0.1278_f64 };
+    const OXFORD: GeoPoint = GeoPoint { lat: 51.8773_f64, long: -1.2475878_f64 };
+
     #[test]
     fn test_geo_spatial_calendar_index() {
         let mut geo_spatial_calendar_index = GeoSpatialCalendarIndex::new();
-
-        let london = GeoPoint::new(51.5074_f64, -0.1278_f64);
-        let oxford = GeoPoint::new(51.8773_f64, -1.2475878_f64);
 
         assert_eq!(
             geo_spatial_calendar_index,
@@ -412,7 +416,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("london_event_uid_one"),
-                &london,
+                &LONDON,
                 &IndexedConclusion::Include(None)
             )
             .is_ok(),);
@@ -421,7 +425,7 @@ mod test {
             geo_spatial_calendar_index,
             GeoSpatialCalendarIndex {
                 coords: RTree::bulk_load(vec![GeomWithData::new(
-                    london.clone(),
+                    LONDON.clone(),
                     InvertedCalendarIndexTerm {
                         events: HashMap::from([(
                             String::from("london_event_uid_one"),
@@ -435,7 +439,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("london_event_uid_two"),
-                &london,
+                &LONDON,
                 &IndexedConclusion::Exclude(Some(HashSet::from([100])))
             )
             .is_ok(),);
@@ -444,7 +448,7 @@ mod test {
             geo_spatial_calendar_index,
             GeoSpatialCalendarIndex {
                 coords: RTree::bulk_load(vec![GeomWithData::new(
-                    london.clone(),
+                    LONDON.clone(),
                     InvertedCalendarIndexTerm {
                         events: HashMap::from([
                             (
@@ -464,7 +468,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("oxford_event_uid"),
-                &oxford,
+                &OXFORD,
                 &IndexedConclusion::Include(Some(HashSet::from([100])))
             )
             .is_ok(),);
@@ -474,7 +478,7 @@ mod test {
             GeoSpatialCalendarIndex {
                 coords: RTree::bulk_load(vec![
                     GeomWithData::new(
-                        london.clone(),
+                        LONDON.clone(),
                         InvertedCalendarIndexTerm {
                             events: HashMap::from([
                                 (
@@ -489,7 +493,7 @@ mod test {
                         }
                     ),
                     GeomWithData::new(
-                        oxford.clone(),
+                        OXFORD.clone(),
                         InvertedCalendarIndexTerm {
                             events: HashMap::from([(
                                 String::from("oxford_event_uid"),
@@ -502,14 +506,14 @@ mod test {
         );
 
         assert!(geo_spatial_calendar_index
-            .remove(String::from("oxford_event_uid"), &oxford)
+            .remove(String::from("oxford_event_uid"), &OXFORD)
             .is_ok());
 
         assert_eq!(
             geo_spatial_calendar_index,
             GeoSpatialCalendarIndex {
                 coords: RTree::bulk_load(vec![GeomWithData::new(
-                    london.clone(),
+                    LONDON.clone(),
                     InvertedCalendarIndexTerm {
                         events: HashMap::from([
                             (
@@ -527,14 +531,14 @@ mod test {
         );
 
         assert!(geo_spatial_calendar_index
-            .remove(String::from("london_event_uid_one"), &london)
+            .remove(String::from("london_event_uid_one"), &LONDON)
             .is_ok());
 
         assert_eq!(
             geo_spatial_calendar_index,
             GeoSpatialCalendarIndex {
                 coords: RTree::bulk_load(vec![GeomWithData::new(
-                    london.clone(),
+                    LONDON.clone(),
                     InvertedCalendarIndexTerm {
                         events: HashMap::from([(
                             String::from("london_event_uid_two"),
@@ -546,14 +550,14 @@ mod test {
         );
 
         assert!(geo_spatial_calendar_index
-            .remove(String::from("london_event_uid_one"), &london)
+            .remove(String::from("london_event_uid_one"), &LONDON)
             .is_ok());
 
         assert_eq!(
             geo_spatial_calendar_index,
             GeoSpatialCalendarIndex {
                 coords: RTree::bulk_load(vec![GeomWithData::new(
-                    london.clone(),
+                    LONDON.clone(),
                     InvertedCalendarIndexTerm {
                         events: HashMap::from([(
                             String::from("london_event_uid_two"),
@@ -565,7 +569,7 @@ mod test {
         );
 
         assert!(geo_spatial_calendar_index
-            .remove(String::from("london_event_uid_two"), &london)
+            .remove(String::from("london_event_uid_two"), &LONDON)
             .is_ok());
 
         assert_eq!(
@@ -580,17 +584,10 @@ mod test {
     fn test_geo_spatial_calendar_index_locate_within_distance() {
         let mut geo_spatial_calendar_index = GeoSpatialCalendarIndex::new();
 
-        let random = GeoPoint::new(51.7854972_f64, -1.4701705_f64);
-        let random_plus_offset = GeoPoint::new(51.785341_f64, -1.470240_f64);
-        let new_york_city = GeoPoint::new(40.7128_f64, -74.006_f64);
-        let churchdown = GeoPoint::new(51.8773_f64, -2.1686_f64);
-        let london = GeoPoint::new(51.5074_f64, -0.1278_f64);
-        let oxford = GeoPoint::new(51.8773_f64, -1.2475878_f64);
-
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("random_event_uid"),
-                &random,
+                &RANDOM,
                 &IndexedConclusion::Include(None),
             )
             .is_ok());
@@ -598,7 +595,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("random_and_churchdown_event_uid"),
-                &random,
+                &RANDOM,
                 &IndexedConclusion::Include(Some(HashSet::from([100, 200]))),
             )
             .is_ok());
@@ -606,7 +603,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("random_plus_offset_event_uid"),
-                &random_plus_offset,
+                &RANDOM_PLUS_OFFSET,
                 &IndexedConclusion::Include(None),
             )
             .is_ok());
@@ -614,7 +611,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("random_plus_offset_and_london_event_uid"),
-                &random_plus_offset,
+                &RANDOM_PLUS_OFFSET,
                 &IndexedConclusion::Exclude(Some(HashSet::from([100]))),
             )
             .is_ok());
@@ -622,7 +619,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("churchdown_event_uid"),
-                &churchdown,
+                &CHURCHDOWN,
                 &IndexedConclusion::Include(None),
             )
             .is_ok());
@@ -630,7 +627,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("random_and_churchdown_event_uid"),
-                &churchdown,
+                &CHURCHDOWN,
                 &IndexedConclusion::Exclude(Some(HashSet::from([200, 300]))),
             )
             .is_ok());
@@ -638,7 +635,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("oxford_event_one_uid"),
-                &oxford,
+                &OXFORD,
                 &IndexedConclusion::Include(None),
             )
             .is_ok());
@@ -646,7 +643,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("oxford_event_two_uid"),
-                &oxford,
+                &OXFORD,
                 &IndexedConclusion::Include(Some(HashSet::from([100, 200]))),
             )
             .is_ok());
@@ -654,7 +651,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("london_event_uid"),
-                &london,
+                &LONDON,
                 &IndexedConclusion::Include(None),
             )
             .is_ok());
@@ -662,7 +659,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("random_plus_offset_and_london_event_uid"),
-                &random_plus_offset,
+                &RANDOM_PLUS_OFFSET,
                 &IndexedConclusion::Include(Some(HashSet::from([100]))),
             )
             .is_ok());
@@ -670,14 +667,14 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("new_york_city_event_uid"),
-                &new_york_city,
+                &NEW_YORK_CITY,
                 &IndexedConclusion::Include(None),
             )
             .is_ok());
 
         assert_eq_sorted!(
             geo_spatial_calendar_index
-                .locate_within_distance(&oxford, &GeoDistance::new_from_kilometers_float(1.0_f64)),
+                .locate_within_distance(&OXFORD, &GeoDistance::new_from_kilometers_float(1.0_f64)),
             InvertedCalendarIndexTerm {
                 events: HashMap::from([
                     (
@@ -694,7 +691,7 @@ mod test {
 
         assert_eq_sorted!(
             geo_spatial_calendar_index
-                .locate_within_distance(&oxford, &GeoDistance::new_from_kilometers_float(87.0_f64)),
+                .locate_within_distance(&OXFORD, &GeoDistance::new_from_kilometers_float(87.0_f64)),
             InvertedCalendarIndexTerm {
                 events: HashMap::from([
                     (
@@ -731,7 +728,7 @@ mod test {
 
         assert_eq_sorted!(
             geo_spatial_calendar_index
-                .locate_within_distance(&oxford, &GeoDistance::new_from_kilometers_float(87.5_f64)),
+                .locate_within_distance(&OXFORD, &GeoDistance::new_from_kilometers_float(87.5_f64)),
             InvertedCalendarIndexTerm {
                 events: HashMap::from([
                     (
@@ -776,54 +773,47 @@ mod test {
     fn test_geo_distance_rtree() {
         let mut tree = RTree::new();
 
-        let random = GeoPoint::new(51.7854972_f64, -1.4701705_f64);
-        let random_plus_offset = GeoPoint::new(51.785341_f64, -1.470240_f64);
-        let new_york_city = GeoPoint::new(40.7128_f64, -74.006_f64);
-        let churchdown = GeoPoint::new(51.8773_f64, -2.1686_f64);
-        let london = GeoPoint::new(51.5074_f64, -0.1278_f64);
-        let oxford = GeoPoint::new(51.8773_f64, -1.2475878_f64);
+        tree.insert(RANDOM.clone());
+        tree.insert(RANDOM_PLUS_OFFSET.clone());
+        tree.insert(NEW_YORK_CITY.clone());
+        tree.insert(CHURCHDOWN.clone());
+        tree.insert(LONDON.clone());
 
-        tree.insert(random.clone());
-        tree.insert(random_plus_offset.clone());
-        tree.insert(new_york_city.clone());
-        tree.insert(churchdown.clone());
-        tree.insert(london.clone());
-
-        let mut results = tree.nearest_neighbor_iter_with_distance_2(&oxford.to_point().clone());
+        let mut results = tree.nearest_neighbor_iter_with_distance_2(&OXFORD.to_point().clone());
 
         let (point, distance) = results.next().unwrap();
 
         // Cast all f64 distances to f32 so tests pass under both MacOS and Linux.
-        assert_eq!((point, distance as f32), (&random, 18388.597009683246_f32));
+        assert_eq!((point, distance as f32), (&RANDOM, 18388.597009683246_f32));
 
         let (point, distance) = results.next().unwrap();
 
         assert_eq!(
             (point, distance),
-            (&random_plus_offset, 18402.23696221235_f64)
+            (&RANDOM_PLUS_OFFSET, 18402.23696221235_f64)
         );
 
         let (point, distance) = results.next().unwrap();
 
         // Cast all f64 distances to f32 so tests pass under both MacOS and Linux.
-        assert_eq!((point, distance as f32), (&churchdown, 63223.39709694925_f32));
+        assert_eq!((point, distance as f32), (&CHURCHDOWN, 63223.39709694925_f32));
 
         let (point, distance) = results.next().unwrap();
 
-        assert_eq!((point, distance), (&london, 87458.64969073102_f64));
+        assert_eq!((point, distance), (&LONDON, 87458.64969073102_f64));
 
         let (point, distance) = results.next().unwrap();
 
         // Cast all f64 distances to f32 so tests pass under both MacOS and Linux.
-        assert_eq!((point, distance as f32), (&new_york_city, 5484158.985172745_f32));
+        assert_eq!((point, distance as f32), (&NEW_YORK_CITY, 5484158.985172745_f32));
 
         assert_eq!(results.next(), None);
 
         let results: Vec<&GeoPoint> = tree
-            .locate_within_distance(oxford.to_point(), 65000.0_f64)
+            .locate_within_distance(OXFORD.to_point(), 65000.0_f64)
             .collect();
 
-        assert_eq_sorted!(results, vec![&churchdown, &random_plus_offset, &random]);
+        assert_eq_sorted!(results, vec![&CHURCHDOWN, &RANDOM_PLUS_OFFSET, &RANDOM]);
     }
 
     #[test]

--- a/redical_core/src/geo_index.rs
+++ b/redical_core/src/geo_index.rs
@@ -402,6 +402,100 @@ mod test {
     const LONDON: GeoPoint = GeoPoint { lat: 51.5074_f64, long: -0.1278_f64 };
     const OXFORD: GeoPoint = GeoPoint { lat: 51.8773_f64, long: -1.2475878_f64 };
 
+    fn example_geo_index() -> GeoSpatialCalendarIndex {
+        let mut geo_spatial_calendar_index = GeoSpatialCalendarIndex::new();
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("random_event_uid"),
+                &RANDOM,
+                &IndexedConclusion::Include(None),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("random_and_churchdown_event_uid"),
+                &RANDOM,
+                &IndexedConclusion::Include(Some(HashSet::from([100, 200]))),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("random_plus_offset_event_uid"),
+                &RANDOM_PLUS_OFFSET,
+                &IndexedConclusion::Include(None),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("random_plus_offset_and_london_event_uid"),
+                &RANDOM_PLUS_OFFSET,
+                &IndexedConclusion::Exclude(Some(HashSet::from([100]))),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("churchdown_event_uid"),
+                &CHURCHDOWN,
+                &IndexedConclusion::Include(None),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("random_and_churchdown_event_uid"),
+                &CHURCHDOWN,
+                &IndexedConclusion::Exclude(Some(HashSet::from([200, 300]))),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("oxford_event_one_uid"),
+                &OXFORD,
+                &IndexedConclusion::Include(None),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("oxford_event_two_uid"),
+                &OXFORD,
+                &IndexedConclusion::Include(Some(HashSet::from([100, 200]))),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("london_event_uid"),
+                &LONDON,
+                &IndexedConclusion::Include(None),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("random_plus_offset_and_london_event_uid"),
+                &LONDON,
+                &IndexedConclusion::Include(Some(HashSet::from([100]))),
+            )
+            .is_ok());
+
+        assert!(geo_spatial_calendar_index
+            .insert(
+                String::from("new_york_city_event_uid"),
+                &NEW_YORK_CITY,
+                &IndexedConclusion::Include(None),
+            )
+            .is_ok());
+
+        geo_spatial_calendar_index
+    }
+
     #[test]
     fn test_geo_spatial_calendar_index() {
         let mut geo_spatial_calendar_index = GeoSpatialCalendarIndex::new();
@@ -582,95 +676,7 @@ mod test {
 
     #[test]
     fn test_geo_spatial_calendar_index_locate_within_distance() {
-        let mut geo_spatial_calendar_index = GeoSpatialCalendarIndex::new();
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("random_event_uid"),
-                &RANDOM,
-                &IndexedConclusion::Include(None),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("random_and_churchdown_event_uid"),
-                &RANDOM,
-                &IndexedConclusion::Include(Some(HashSet::from([100, 200]))),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("random_plus_offset_event_uid"),
-                &RANDOM_PLUS_OFFSET,
-                &IndexedConclusion::Include(None),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("random_plus_offset_and_london_event_uid"),
-                &RANDOM_PLUS_OFFSET,
-                &IndexedConclusion::Exclude(Some(HashSet::from([100]))),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("churchdown_event_uid"),
-                &CHURCHDOWN,
-                &IndexedConclusion::Include(None),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("random_and_churchdown_event_uid"),
-                &CHURCHDOWN,
-                &IndexedConclusion::Exclude(Some(HashSet::from([200, 300]))),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("oxford_event_one_uid"),
-                &OXFORD,
-                &IndexedConclusion::Include(None),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("oxford_event_two_uid"),
-                &OXFORD,
-                &IndexedConclusion::Include(Some(HashSet::from([100, 200]))),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("london_event_uid"),
-                &LONDON,
-                &IndexedConclusion::Include(None),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("random_plus_offset_and_london_event_uid"),
-                &LONDON,
-                &IndexedConclusion::Include(Some(HashSet::from([100]))),
-            )
-            .is_ok());
-
-        assert!(geo_spatial_calendar_index
-            .insert(
-                String::from("new_york_city_event_uid"),
-                &NEW_YORK_CITY,
-                &IndexedConclusion::Include(None),
-            )
-            .is_ok());
+        let geo_spatial_calendar_index = example_geo_index();
 
         assert_eq_sorted!(
             geo_spatial_calendar_index

--- a/redical_core/src/geo_index.rs
+++ b/redical_core/src/geo_index.rs
@@ -659,7 +659,7 @@ mod test {
         assert!(geo_spatial_calendar_index
             .insert(
                 String::from("random_plus_offset_and_london_event_uid"),
-                &RANDOM_PLUS_OFFSET,
+                &LONDON,
                 &IndexedConclusion::Include(Some(HashSet::from([100]))),
             )
             .is_ok());
@@ -716,7 +716,7 @@ mod test {
                     ),
                     (
                         String::from("random_plus_offset_and_london_event_uid"),
-                        IndexedConclusion::Include(Some(HashSet::from([100])))
+                        IndexedConclusion::Exclude(Some(HashSet::from([100])))
                     ),
                     (
                         String::from("random_plus_offset_event_uid"),
@@ -753,7 +753,7 @@ mod test {
                     ),
                     (
                         String::from("random_plus_offset_and_london_event_uid"),
-                        IndexedConclusion::Include(Some(HashSet::from([100])))
+                        IndexedConclusion::Include(None)
                     ),
                     (
                         String::from("random_plus_offset_event_uid"),

--- a/redical_core/src/queries/event_instance_query.rs
+++ b/redical_core/src/queries/event_instance_query.rs
@@ -438,7 +438,346 @@ mod test {
     use crate::{GeoPoint, KeyValuePair};
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
-    use std::collections::HashSet;
+    use std::collections::{HashSet, HashMap};
+
+    #[test]
+    fn test_uid_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let event_one = Event::parse_ical("EVENT_ONE", "").unwrap();
+        let event_two = Event::parse_ical("EVENT_TWO", "").unwrap();
+        let event_three = Event::parse_ical("EVENT_THREE", "").unwrap();
+
+        calendar.insert_event(event_one);
+        calendar.insert_event(event_two);
+        calendar.insert_event(event_three);
+        calendar.rebuild_indexes().unwrap();
+
+        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_uid_index("EVENT_ONE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_ONE"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // TODO: Shouldn't this return an empty event set?
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_uid_index("EVENT_FOUR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_FOUR"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+    }
+
+    #[test]
+    fn test_location_type_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_location_types = [
+            (
+                String::from("ONLINE"),
+                [
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly in person"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("IN-PERSON"),
+                [
+                    (String::from("All in person"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in person"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly online"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            )
+        ];
+
+        for (location_type, events) in indexed_location_types.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_location_type.insert(
+                    event_uid.to_string(),
+                    location_type.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_location_type_index("ONLINE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly in person"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_location_type_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_categories_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_categories = [
+            (
+                String::from("Adults"),
+                [
+                    (String::from("All adults"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly adults"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly kids"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("Kids"),
+                [
+                    (String::from("All kids"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly kids"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly adults"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+        ];
+
+        for (category, events) in indexed_categories.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_categories.insert(
+                    event_uid.to_string(),
+                    category.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_categories_index("Kids"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All kids"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly kids"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly adults"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_categories_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_related_to_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_related_to = [
+            (
+                KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-1"),
+                ),
+                [
+                    (String::from("All account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-1"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly account-2"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-2"),
+                ),
+                [
+                    (String::from("All account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-2"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly account-1"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+        ];
+
+        for (related_to, events) in indexed_related_to.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_related_to.insert(
+                    event_uid.to_string(),
+                    related_to.clone(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-1"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-1"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly account-2"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-4"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_geo_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        const LONDON: GeoPoint = GeoPoint { lat: 51.5074_f64, long: -0.1278_f64 };
+        const OXFORD: GeoPoint = GeoPoint { lat: 51.8773_f64, long: -1.2475878_f64 };
+        const NEW_YORK_CITY: GeoPoint = GeoPoint { lat: 40.7128_f64, long: -74.006_f64 };
+
+        let indexed_geo = [
+            (
+                LONDON,
+                [
+                    (String::from("All in London"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in London"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                OXFORD,
+                [
+                    (String::from("All in Oxford"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly in London"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+        ];
+
+        for (geo_point, events) in indexed_geo.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_geo.insert(
+                    event_uid.to_string(),
+                    geo_point,
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+
+        let search_distance = GeoDistance::new_from_miles_float(10.0_f64);
+
+        // Positive matching: events located within search distance
+        assert_eq!(
+            accessor.search_geo_index(&search_distance, &OXFORD),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All in Oxford"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly in London"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]),
+            }
+        );
+
+        // Positive matching: no events located within search distance
+        assert_eq!(
+            accessor.search_geo_index(&search_distance, &NEW_YORK_CITY),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_class_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_class = [
+            (
+                String::from("PUBLIC"),
+                [
+                    (String::from("All public"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly public"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly private"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("PRIVATE"),
+                [
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly public"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+        ];
+
+        for (class, events) in indexed_class.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_class.insert(
+                    event_uid.to_string(),
+                    class.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_class_index("PRIVATE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly public"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_class_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
 
     #[test]
     fn test_event_instance_query_index_accessor() {

--- a/redical_core/src/queries/event_instance_query.rs
+++ b/redical_core/src/queries/event_instance_query.rs
@@ -28,13 +28,17 @@ use crate::MergedIterator;
 /// extrapolation process combines them to ensure overridden indexed property values are reflected
 /// for specific occurrences.
 pub struct EventInstanceQueryIndexAccessor<'cal> {
-    calendar: &'cal Calendar
+    calendar: &'cal Calendar,
+    event_uids: Vec<String>,
 }
 
 impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
     fn new(calendar: &'cal Calendar) -> Self {
+        let event_uids = calendar.events.keys().cloned().collect();
+
         EventInstanceQueryIndexAccessor {
             calendar,
+            event_uids,
         }
     }
 
@@ -510,7 +514,17 @@ mod test {
             }
         }
 
-        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All in person"),
+            String::from("All online"),
+            String::from("Mostly in person"),
+            String::from("Mostly online"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventInstanceQueryIndexAccessor { calendar: &calendar, event_uids };
 
         // Positive matching: term exists
         assert_eq!(
@@ -566,7 +580,17 @@ mod test {
             }
         }
 
-        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All adults"),
+            String::from("All kids"),
+            String::from("Mostly adults"),
+            String::from("Mostly kids"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventInstanceQueryIndexAccessor { calendar: &calendar, event_uids };
 
         // Positive matching: term exists
         assert_eq!(
@@ -628,7 +652,17 @@ mod test {
             }
         }
 
-        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All account-1"),
+            String::from("All account-2"),
+            String::from("Mostly account-1"),
+            String::from("Mostly account-2"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventInstanceQueryIndexAccessor { calendar: &calendar, event_uids };
 
         // Positive matching: term exists
         assert_eq!(
@@ -698,7 +732,17 @@ mod test {
             }
         }
 
-        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All in London"),
+            String::from("All in Oxford"),
+            String::from("Mostly in London"),
+            String::from("Mostly in Oxford"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventInstanceQueryIndexAccessor { calendar: &calendar, event_uids };
 
         let search_distance = GeoDistance::new_from_miles_float(10.0_f64);
 
@@ -756,7 +800,17 @@ mod test {
             }
         }
 
-        let accessor = EventInstanceQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All public"),
+            String::from("All private"),
+            String::from("Mostly public"),
+            String::from("Mostly private"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventInstanceQueryIndexAccessor { calendar: &calendar, event_uids };
 
         // Positive matching: term exists
         assert_eq!(

--- a/redical_core/src/queries/event_instance_query.rs
+++ b/redical_core/src/queries/event_instance_query.rs
@@ -87,6 +87,30 @@ impl<'cal> QueryIndexAccessor<'cal> for EventInstanceQueryIndexAccessor<'cal> {
             .unwrap_or(&InvertedCalendarIndexTerm::new())
             .to_owned()
     }
+
+    fn search_not_uid_index(&self, uid: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
 }
 
 /// This struct implements all the query logic specific to querying all the event instances on a

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -26,7 +26,8 @@ use crate::queries::results_range_bounds::{
 /// `IndexedConclusion::Include` with exceptions defined, it will return a clone of it without any
 /// exceptions.
 pub struct EventQueryIndexAccessor<'cal> {
-    calendar: &'cal Calendar
+    calendar: &'cal Calendar,
+    event_uids: Vec<String>,
 }
 
 impl EventQueryIndexAccessor<'_> {
@@ -51,8 +52,11 @@ impl EventQueryIndexAccessor<'_> {
 
 impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
     fn new(calendar: &'cal Calendar) -> Self {
+        let event_uids = calendar.events.keys().cloned().collect();
+
         EventQueryIndexAccessor {
             calendar,
+            event_uids,
         }
     }
 
@@ -540,7 +544,17 @@ mod test {
             }
         }
 
-        let accessor = EventQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All in person"),
+            String::from("All online"),
+            String::from("Mostly in person"),
+            String::from("Mostly online"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventQueryIndexAccessor { calendar: &calendar, event_uids };
 
         // Positive matching: term exists
         assert_eq!(
@@ -595,7 +609,17 @@ mod test {
             }
         }
 
-        let accessor = EventQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All adults"),
+            String::from("All kids"),
+            String::from("Mostly adults"),
+            String::from("Mostly kids"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventQueryIndexAccessor { calendar: &calendar, event_uids };
 
         // Positive matching: term exists
         assert_eq!(
@@ -656,7 +680,17 @@ mod test {
             }
         }
 
-        let accessor = EventQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All account-1"),
+            String::from("All account-2"),
+            String::from("Mostly account-1"),
+            String::from("Mostly account-2"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventQueryIndexAccessor { calendar: &calendar, event_uids };
 
         // Positive matching: term exists
         assert_eq!(
@@ -725,7 +759,17 @@ mod test {
             }
         }
 
-        let accessor = EventQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All in London"),
+            String::from("All in Oxford"),
+            String::from("Mostly in London"),
+            String::from("Mostly in Oxford"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventQueryIndexAccessor { calendar: &calendar, event_uids };
 
         let search_distance = GeoDistance::new_from_miles_float(10.0_f64);
 
@@ -782,7 +826,17 @@ mod test {
             }
         }
 
-        let accessor = EventQueryIndexAccessor::new(&calendar);
+        // Contains extra event uids to simulate events referenced on other indexes.
+        let event_uids = vec![
+            String::from("All public"),
+            String::from("All private"),
+            String::from("Mostly public"),
+            String::from("Mostly private"),
+            String::from("Other event 1"),
+            String::from("Other event 2"),
+        ];
+
+        let accessor = EventQueryIndexAccessor { calendar: &calendar, event_uids };
 
         // Positive matching: term exists
         assert_eq!(

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -468,7 +468,341 @@ mod test {
     use crate::{GeoPoint, KeyValuePair};
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
-    use std::collections::HashSet;
+    use std::collections::{HashSet, HashMap};
+
+    #[test]
+    fn test_uid_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let event_one = Event::parse_ical("EVENT_ONE", "").unwrap();
+        let event_two = Event::parse_ical("EVENT_TWO", "").unwrap();
+        let event_three = Event::parse_ical("EVENT_THREE", "").unwrap();
+
+        calendar.insert_event(event_one);
+        calendar.insert_event(event_two);
+        calendar.insert_event(event_three);
+        calendar.rebuild_indexes().unwrap();
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_uid_index("EVENT_ONE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_ONE"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // TODO: Shouldn't this return an empty event set?
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_uid_index("EVENT_FOUR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_FOUR"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+    }
+
+    #[test]
+    fn test_location_type_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_location_types = [
+            (
+                String::from("ONLINE"),
+                [
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly in person"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("IN-PERSON"),
+                [
+                    (String::from("All in person"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in person"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly online"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            )
+        ];
+
+        for (location_type, events) in indexed_location_types.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_location_type.insert(
+                    event_uid.to_string(),
+                    location_type.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_location_type_index("ONLINE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_location_type_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_categories_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_categories = [
+            (
+                String::from("Adults"),
+                [
+                    (String::from("All adults"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly adults"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly kids"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("Kids"),
+                [
+                    (String::from("All kids"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly kids"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly adults"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+        ];
+
+        for (category, events) in indexed_categories.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_categories.insert(
+                    event_uid.to_string(),
+                    category.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_categories_index("Kids"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All kids"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly kids"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_categories_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_related_to_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_related_to = [
+            (
+                KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-1"),
+                ),
+                [
+                    (String::from("All account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-1"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly account-2"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-2"),
+                ),
+                [
+                    (String::from("All account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-2"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly account-1"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+        ];
+
+        for (related_to, events) in indexed_related_to.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_related_to.insert(
+                    event_uid.to_string(),
+                    related_to.clone(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-1"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-1"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-4"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_geo_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        const LONDON: GeoPoint = GeoPoint { lat: 51.5074_f64, long: -0.1278_f64 };
+        const OXFORD: GeoPoint = GeoPoint { lat: 51.8773_f64, long: -1.2475878_f64 };
+        const NEW_YORK_CITY: GeoPoint = GeoPoint { lat: 40.7128_f64, long: -74.006_f64 };
+
+        let indexed_geo = [
+            (
+                LONDON,
+                [
+                    (String::from("All in London"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in London"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                OXFORD,
+                [
+                    (String::from("All in Oxford"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly in London"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+        ];
+
+        for (geo_point, events) in indexed_geo.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_geo.insert(
+                    event_uid.to_string(),
+                    geo_point,
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        let search_distance = GeoDistance::new_from_miles_float(10.0_f64);
+
+        // Positive matching: events located within search distance
+        assert_eq!(
+            accessor.search_geo_index(&search_distance, &OXFORD),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All in Oxford"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: no events located within search distance
+        assert_eq!(
+            accessor.search_geo_index(&search_distance, &NEW_YORK_CITY),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
+
+    #[test]
+    fn test_class_index_retrieval() {
+        let mut calendar = Calendar::new(String::from("CALENDAR_UID"));
+
+        let indexed_class = [
+            (
+                String::from("PUBLIC"),
+                [
+                    (String::from("All public"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly public"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly private"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+            (
+                String::from("PRIVATE"),
+                [
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(Some([100].into()))),
+                    (String::from("Mostly public"), IndexedConclusion::Exclude(Some([100].into()))),
+                ]
+            ),
+        ];
+
+        for (class, events) in indexed_class.iter() {
+            for (event_uid, conclusion) in events.iter() {
+                calendar.indexed_class.insert(
+                    event_uid.to_string(),
+                    class.to_string(),
+                    conclusion
+                ).unwrap();
+            }
+        }
+
+        let accessor = EventQueryIndexAccessor::new(&calendar);
+
+        // Positive matching: term exists
+        assert_eq!(
+            accessor.search_class_index("PRIVATE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Positive matching: term does not exist
+        assert_eq!(
+            accessor.search_class_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::new(),
+            }
+        );
+    }
 
     #[test]
     fn test_event_query_index_accessor() {

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -1,3 +1,4 @@
+use std::collections::HashMap;
 use std::str::FromStr;
 
 use chrono_tz::Tz;
@@ -101,27 +102,73 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
     }
 
     fn search_not_uid_index(&self, uid: &str) -> InvertedCalendarIndexTerm {
-        todo!();
+        let mut event_uids = self.event_uids.clone();
+
+        event_uids.retain(|event_uid| event_uid != uid);
+
+        InvertedCalendarIndexTerm {
+            events: HashMap::from_iter(
+                event_uids.into_iter().map(|event_uid| 
+                    (event_uid, IndexedConclusion::Include(None)),
+                )
+            ),
+        }
     }
 
     fn search_not_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
-        todo!();
+        let inverse_matches = self.calendar.indexed_location_type.get_not_term(
+            &location_type.to_string(),
+            &self.event_uids,
+        );
+
+        Self::included_conclusions_or_nothing(
+            Some(&inverse_matches)
+        )
     }
 
     fn search_not_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
-        todo!();
+        let inverse_matches = self.calendar.indexed_categories.get_not_term(
+            &category.to_string(),
+            &self.event_uids,
+        );
+
+        Self::included_conclusions_or_nothing(
+            Some(&inverse_matches)
+        )
     }
 
     fn search_not_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
-        todo!();
+        let inverse_matches = self.calendar.indexed_related_to.get_not_term(
+            reltype_uids,
+            &self.event_uids,
+        );
+
+        Self::included_conclusions_or_nothing(
+            Some(&inverse_matches)
+        )
     }
 
     fn search_not_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm {
-        todo!();
+        let inverse_matches = self.calendar.indexed_geo.locate_not_within_distance(
+            long_lat,
+            distance,
+            &self.event_uids,
+        );
+
+        Self::included_conclusions_or_nothing(
+            Some(&inverse_matches)
+        )
     }
 
     fn search_not_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
-        todo!();
+        let inverse_matches = self.calendar.indexed_class.get_not_term(
+            &class.to_string(),
+            &self.event_uids,
+        );
+
+        Self::included_conclusions_or_nothing(
+            Some(&inverse_matches)
+        )
     }
 }
 
@@ -496,7 +543,7 @@ mod test {
     use crate::{GeoPoint, KeyValuePair};
     use pretty_assertions_sorted::{assert_eq, assert_eq_sorted};
 
-    use std::collections::{HashSet, HashMap};
+    use std::collections::HashSet;
 
     #[test]
     fn test_uid_index_retrieval() {
@@ -530,6 +577,29 @@ mod test {
             InvertedCalendarIndexTerm {
                 events: HashMap::from([
                     (String::from("EVENT_FOUR"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Negative matching: term exists
+        assert_eq!(
+            accessor.search_not_uid_index("EVENT_ONE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_TWO"), IndexedConclusion::Include(None)),
+                    (String::from("EVENT_THREE"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
+
+        // Negative matching: term does not exist
+        assert_eq!(
+            accessor.search_not_uid_index("EVENT_FOUR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("EVENT_ONE"), IndexedConclusion::Include(None)),
+                    (String::from("EVENT_TWO"), IndexedConclusion::Include(None)),
+                    (String::from("EVENT_THREE"), IndexedConclusion::Include(None)),
                 ]),
             }
         );
@@ -598,6 +668,34 @@ mod test {
                 events: HashMap::new(),
             }
         );
+
+        // Negative matching: term exists
+        assert_eq!(
+            accessor.search_not_location_type_index("ONLINE"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All in person"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in person"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ])
+            }
+        );
+
+        // Negative matching: term does not exist
+        assert_eq!(
+            accessor.search_not_categories_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All online"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly online"), IndexedConclusion::Include(None)),
+                    (String::from("All in person"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in person"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
     }
 
     #[test]
@@ -661,6 +759,34 @@ mod test {
             accessor.search_categories_index("FOOBAR"),
             InvertedCalendarIndexTerm {
                 events: HashMap::new(),
+            }
+        );
+
+        // Negative matching: term exists
+        assert_eq!(
+            accessor.search_not_categories_index("Kids"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All adults"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly adults"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ])
+            }
+        );
+
+        // Negative matching: term does not exist
+        assert_eq!(
+            accessor.search_not_categories_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All adults"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly adults"), IndexedConclusion::Include(None)),
+                    (String::from("All kids"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly kids"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ]),
             }
         );
     }
@@ -744,6 +870,44 @@ mod test {
                 events: HashMap::new(),
             }
         );
+
+        // Negative matching: term exists
+        assert_eq!(
+            accessor.search_not_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("account-1"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ])
+            }
+        );
+
+        // Negative matching: term does not exist
+        assert_eq!(
+            accessor.search_not_related_to_index(
+                &KeyValuePair::new(
+                    String::from("X-ACCOUNT"),
+                    String::from("FOOBAR"),
+                )
+            ),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All account-1"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-1"), IndexedConclusion::Include(None)),
+                    (String::from("All account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly account-2"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
     }
 
     #[test]
@@ -815,6 +979,34 @@ mod test {
                 events: HashMap::new(),
             }
         );
+
+        // Negative matching: some events located outside search distance
+        assert_eq!(
+            accessor.search_not_geo_index(&search_distance, &OXFORD),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All in London"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in London"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ])
+            }
+        );
+
+        // Negative matching: all events outside search distance
+        assert_eq!(
+            accessor.search_not_geo_index(&search_distance, &NEW_YORK_CITY),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All in London"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in London"), IndexedConclusion::Include(None)),
+                    (String::from("All in Oxford"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly in Oxford"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ]),
+            }
+        );
     }
 
     #[test]
@@ -878,6 +1070,34 @@ mod test {
             accessor.search_class_index("FOOBAR"),
             InvertedCalendarIndexTerm {
                 events: HashMap::new(),
+            }
+        );
+
+        // Negative matching: term exists
+        assert_eq!(
+            accessor.search_not_class_index("PUBLIC"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ])
+            }
+        );
+
+        // Negative matching: term does not exist
+        assert_eq!(
+            accessor.search_not_class_index("FOOBAR"),
+            InvertedCalendarIndexTerm {
+                events: HashMap::from([
+                    (String::from("All public"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly public"), IndexedConclusion::Include(None)),
+                    (String::from("All private"), IndexedConclusion::Include(None)),
+                    (String::from("Mostly private"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 1"), IndexedConclusion::Include(None)),
+                    (String::from("Other event 2"), IndexedConclusion::Include(None)),
+                ]),
             }
         );
     }

--- a/redical_core/src/queries/event_query.rs
+++ b/redical_core/src/queries/event_query.rs
@@ -99,6 +99,30 @@ impl<'cal> QueryIndexAccessor<'cal> for EventQueryIndexAccessor<'cal> {
             self.calendar.indexed_class.get_term(&class.to_string())
         )
     }
+
+    fn search_not_uid_index(&self, uid: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
+
+    fn search_not_class_index(&self, class: &str) -> InvertedCalendarIndexTerm {
+        todo!();
+    }
 }
 
 /// This struct implements all the query logic specific to querying events on a calendar (not the

--- a/redical_core/src/queries/query.rs
+++ b/redical_core/src/queries/query.rs
@@ -28,12 +28,22 @@ use crate::queries::indexed_property_filters::{
 /// exceptions.
 pub trait QueryIndexAccessor<'cal> {
     fn new(calendar: &'cal Calendar) -> Self;
+
+    // Positive term matching
     fn search_uid_index(&self, uid: &str) -> InvertedCalendarIndexTerm;
     fn search_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm;
     fn search_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm;
     fn search_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm;
     fn search_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm;
     fn search_class_index(&self, class: &str) -> InvertedCalendarIndexTerm;
+
+    // Negative term (NOT) matching
+    fn search_not_uid_index(&self, uid: &str) -> InvertedCalendarIndexTerm;
+    fn search_not_location_type_index(&self, location_type: &str) -> InvertedCalendarIndexTerm;
+    fn search_not_categories_index(&self, category: &str) -> InvertedCalendarIndexTerm;
+    fn search_not_related_to_index(&self, reltype_uids: &KeyValuePair) -> InvertedCalendarIndexTerm;
+    fn search_not_geo_index(&self, distance: &GeoDistance, long_lat: &GeoPoint) -> InvertedCalendarIndexTerm;
+    fn search_not_class_index(&self, class: &str) -> InvertedCalendarIndexTerm;
 }
 
 /// The purpose of this trait is to allow it's implementers to specify the query logic specific to


### PR DESCRIPTION
- This PR extends the `QueryIndexAccessor` trait with a negative matching interface
- Each `search_X` method now has an analogous `search_not_X` method to search where the given term does not match
- This is implemented through the `InvertedCalendarIndex.get_not_term` and `GeoSpatialCalendarIndex.locate_not_within_distance` methods to return a virtual index event set.
- The negative querying methods require the context of all event_uids in the calendar as there may be events that exist (are indexed in other index event sets) but are not set in the context of the current index.
- To implement this cleanly, the `EventQueryIndexAccessor` and `EventInstanceQueryIndexAccessor` structs now set a `Vec<String>` of all event uids on the calendar during initialisation by the respective `new` methods.
- This allows the event uids to be overridden by setting directly for testing purposes.
