### PR TITLE
Resolve crash on parsing timezone aware date time within DST transition gap 

### DIFF
--- a/redical_ical/src/lib.rs
+++ b/redical_ical/src/lib.rs
@@ -471,7 +471,7 @@ mod tests {
 
     #[macro_export]
     macro_rules! assert_parser_error {
-        ($subject:expr, nom::Err::Error(span: $span:expr, message: $message:expr, context: [$($context:expr $(,)*)+ $(,)*] $(,)*) $(,)*) => {
+        ($subject:expr, nom::Err::Error(span: $span:expr, message: $message:expr, context: [$($context:expr $(,)*)* $(,)*] $(,)*) $(,)*) => {
             let result = $subject;
 
             let Err(nom::Err::Error(parser_error)) = result else {
@@ -483,15 +483,15 @@ mod tests {
 
             pretty_assertions_sorted::assert_eq!(
                 parser_error.context,
-                vec![
+                Vec::<String>::from([
                     $(
                         $context.to_string(),
-                    )+
-                ],
+                    )*
+                ]),
             );
         };
 
-        ($subject:expr, nom::Err::Failure(span: $span:expr, message: $message:expr, context: [$($context:expr $(,)*)+ $(,)*] $(,)*) $(,)*) => {
+        ($subject:expr, nom::Err::Failure(span: $span:expr, message: $message:expr, context: [$($context:expr $(,)*)* $(,)*] $(,)*) $(,)*) => {
             let result = $subject;
 
             let Err(nom::Err::Failure(parser_error)) = result else {
@@ -503,11 +503,11 @@ mod tests {
 
             pretty_assertions_sorted::assert_eq!(
                 parser_error.context,
-                vec![
+                Vec::<String>::from([
                     $(
                         $context.to_string(),
-                    )+
-                ],
+                    )*
+                ]),
             );
         };
     }

--- a/redical_ical/src/properties/event/dtend.rs
+++ b/redical_ical/src/properties/event/dtend.rs
@@ -4,7 +4,7 @@ use nom::error::context;
 use nom::branch::alt;
 use nom::sequence::{pair, preceded};
 use nom::multi::separated_list1;
-use nom::combinator::{recognize, map, cut, opt};
+use nom::combinator::{recognize, map_res, cut, opt};
 
 use crate::values::date_time::{DateTime, ValueType};
 use crate::values::tzid::Tzid;
@@ -15,7 +15,7 @@ use crate::properties::{ICalendarProperty, ICalendarPropertyParams, ICalendarDat
 
 use crate::content_line::{ContentLineParams, ContentLine};
 
-use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, impl_icalendar_entity_traits};
+use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, ParserError, impl_icalendar_entity_traits};
 
 use std::collections::HashMap;
 
@@ -180,16 +180,25 @@ impl ICalendarEntity for DTEndProperty {
             preceded(
                 tag("DTEND"),
                 cut(
-                    map(
+                    map_res(
                         pair(
                             opt(DTEndPropertyParams::parse_ical),
                             preceded(colon, DateTime::parse_ical),
                         ),
                         |(params, date_time)| {
-                            DTEndProperty {
-                                params: params.unwrap_or(DTEndPropertyParams::default()),
-                                date_time,
+                            let dtstart_property =
+                                DTEndProperty {
+                                    params: params.unwrap_or(DTEndPropertyParams::default()),
+                                    date_time,
+                                };
+
+                            if let Err(error) = ICalendarEntity::validate(&dtstart_property) {
+                                return Err(
+                                    ParserError::new(error, input)
+                                );
                             }
+
+                            Ok(dtstart_property)
                         }
                     )
                 )
@@ -206,6 +215,8 @@ impl ICalendarEntity for DTEndProperty {
 
         if let Some(tzid) = self.params.tzid.as_ref() {
             tzid.validate()?;
+
+            tzid.validate_with_datetime_value(&self.date_time)?;
         };
 
         if let Some(value_type) = self.params.value_type.as_ref() {
@@ -257,7 +268,7 @@ mod tests {
     use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     use chrono_tz::Tz;
 
-    use crate::tests::assert_parser_output;
+    use crate::tests::{assert_parser_output, assert_parser_error};
 
     #[test]
     fn parse_ical() {
@@ -318,6 +329,60 @@ mod tests {
         );
 
         assert!(DTEndProperty::parse_ical(":".into()).is_err());
+    }
+
+    #[test]
+    fn parse_ical_wth_impossible_tz_date_time() {
+        // Assert impossible date/time fails validation.
+        assert_parser_error!(
+            DTEndProperty::parse_ical("DTEND;TZID=Pacific/Auckland:20240929T020000".into()),
+            nom::Err::Failure(
+                span: ";TZID=Pacific/Auckland:20240929T020000",
+                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"DTEND;TZID=Pacific/Auckland:20240929T020000\"",
+                context: ["DTEND"],
+            ),
+        );
+
+        // Assert possible date/time does not fail validation.
+        assert_parser_output!(
+            DTEndProperty::parse_ical("DTEND;TZID=Pacific/Auckland:20240929T010000".into()),
+            (
+                "",
+                DTEndProperty {
+                    params: DTEndPropertyParams {
+                        value_type: None,
+                        tzid: Some(Tzid(Tz::Pacific__Auckland)),
+                        other: HashMap::new(),
+                    },
+                    date_time: DateTime::LocalDateTime(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2024_i32, 9_u32, 29_u32).unwrap(),
+                            NaiveTime::from_hms_opt(1_u32, 0_u32, 0_u32).unwrap(),
+                        )
+                    ),
+                },
+            ),
+        );
+
+        assert_parser_output!(
+            DTEndProperty::parse_ical("DTEND;TZID=Pacific/Auckland:20240929T030000".into()),
+            (
+                "",
+                DTEndProperty {
+                    params: DTEndPropertyParams {
+                        value_type: None,
+                        tzid: Some(Tzid(Tz::Pacific__Auckland)),
+                        other: HashMap::new(),
+                    },
+                    date_time: DateTime::LocalDateTime(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2024_i32, 9_u32, 29_u32).unwrap(),
+                            NaiveTime::from_hms_opt(3_u32, 0_u32, 0_u32).unwrap(),
+                        )
+                    ),
+                },
+            ),
+        );
     }
 
     #[test]

--- a/redical_ical/src/properties/event/dtend.rs
+++ b/redical_ical/src/properties/event/dtend.rs
@@ -338,7 +338,7 @@ mod tests {
             DTEndProperty::parse_ical("DTEND;TZID=Pacific/Auckland:20240929T020000".into()),
             nom::Err::Failure(
                 span: ";TZID=Pacific/Auckland:20240929T020000",
-                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"DTEND;TZID=Pacific/Auckland:20240929T020000\"",
+                message: "Error - detected timezone aware datetime within a DST transition gap (supply this as UTC or fully DST adjusted) at \"DTEND;TZID=Pacific/Auckland:20240929T020000\"",
                 context: ["DTEND"],
             ),
         );

--- a/redical_ical/src/properties/event/dtend.rs
+++ b/redical_ical/src/properties/event/dtend.rs
@@ -332,7 +332,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_ical_wth_impossible_tz_date_time() {
+    fn parse_ical_wth_tz_dst_gap_date_time() {
         // Assert impossible date/time fails validation.
         assert_parser_error!(
             DTEndProperty::parse_ical("DTEND;TZID=Pacific/Auckland:20240929T020000".into()),

--- a/redical_ical/src/properties/event/dtstart.rs
+++ b/redical_ical/src/properties/event/dtstart.rs
@@ -335,7 +335,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_ical_wth_impossible_tz_date_time() {
+    fn parse_ical_wth_tz_dst_gap_date_time() {
         // Assert impossible date/time fails validation.
         assert_parser_error!(
             DTStartProperty::parse_ical("DTSTART;TZID=Pacific/Auckland:20240929T020000".into()),

--- a/redical_ical/src/properties/event/dtstart.rs
+++ b/redical_ical/src/properties/event/dtstart.rs
@@ -341,7 +341,7 @@ mod tests {
             DTStartProperty::parse_ical("DTSTART;TZID=Pacific/Auckland:20240929T020000".into()),
             nom::Err::Failure(
                 span: ";TZID=Pacific/Auckland:20240929T020000",
-                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"DTSTART;TZID=Pacific/Auckland:20240929T020000\"",
+                message: "Error - detected timezone aware datetime within a DST transition gap (supply this as UTC or fully DST adjusted) at \"DTSTART;TZID=Pacific/Auckland:20240929T020000\"",
                 context: ["DTSTART"],
             ),
         );

--- a/redical_ical/src/properties/event/dtstart.rs
+++ b/redical_ical/src/properties/event/dtstart.rs
@@ -4,7 +4,7 @@ use nom::error::context;
 use nom::branch::alt;
 use nom::sequence::{pair, preceded};
 use nom::multi::separated_list1;
-use nom::combinator::{recognize, map, cut, opt};
+use nom::combinator::{recognize, map_res, cut, opt};
 
 use crate::values::date_time::{DateTime, ValueType};
 use crate::values::tzid::Tzid;
@@ -15,7 +15,7 @@ use crate::properties::{ICalendarProperty, ICalendarPropertyParams, ICalendarDat
 
 use crate::content_line::{ContentLineParams, ContentLine};
 
-use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, impl_icalendar_entity_traits};
+use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, ParserError, impl_icalendar_entity_traits};
 
 use std::collections::HashMap;
 
@@ -183,16 +183,25 @@ impl ICalendarEntity for DTStartProperty {
             preceded(
                 tag("DTSTART"),
                 cut(
-                    map(
+                    map_res(
                         pair(
                             opt(DTStartPropertyParams::parse_ical),
                             preceded(colon, DateTime::parse_ical),
                         ),
                         |(params, date_time)| {
-                            DTStartProperty {
-                                params: params.unwrap_or(DTStartPropertyParams::default()),
-                                date_time,
+                            let dtstart_property =
+                                DTStartProperty {
+                                    params: params.unwrap_or(DTStartPropertyParams::default()),
+                                    date_time,
+                                };
+
+                            if let Err(error) = ICalendarEntity::validate(&dtstart_property) {
+                                return Err(
+                                    ParserError::new(error, input)
+                                );
                             }
+
+                            Ok(dtstart_property)
                         }
                     )
                 )
@@ -209,6 +218,8 @@ impl ICalendarEntity for DTStartProperty {
 
         if let Some(tzid) = self.params.tzid.as_ref() {
             tzid.validate()?;
+
+            tzid.validate_with_datetime_value(&self.date_time)?;
         };
 
         if let Some(value_type) = self.params.value_type.as_ref() {
@@ -260,7 +271,7 @@ mod tests {
     use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     use chrono_tz::Tz;
 
-    use crate::tests::assert_parser_output;
+    use crate::tests::{assert_parser_output, assert_parser_error};
 
     #[test]
     fn parse_ical() {
@@ -321,6 +332,60 @@ mod tests {
         );
 
         assert!(DTStartProperty::parse_ical(":".into()).is_err());
+    }
+
+    #[test]
+    fn parse_ical_wth_impossible_tz_date_time() {
+        // Assert impossible date/time fails validation.
+        assert_parser_error!(
+            DTStartProperty::parse_ical("DTSTART;TZID=Pacific/Auckland:20240929T020000".into()),
+            nom::Err::Failure(
+                span: ";TZID=Pacific/Auckland:20240929T020000",
+                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"DTSTART;TZID=Pacific/Auckland:20240929T020000\"",
+                context: ["DTSTART"],
+            ),
+        );
+
+        // Assert possible date/time does not fail validation.
+        assert_parser_output!(
+            DTStartProperty::parse_ical("DTSTART;TZID=Pacific/Auckland:20240929T010000".into()),
+            (
+                "",
+                DTStartProperty {
+                    params: DTStartPropertyParams {
+                        value_type: None,
+                        tzid: Some(Tzid(Tz::Pacific__Auckland)),
+                        other: HashMap::new(),
+                    },
+                    date_time: DateTime::LocalDateTime(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2024_i32, 9_u32, 29_u32).unwrap(),
+                            NaiveTime::from_hms_opt(1_u32, 0_u32, 0_u32).unwrap(),
+                        )
+                    ),
+                },
+            ),
+        );
+
+        assert_parser_output!(
+            DTStartProperty::parse_ical("DTSTART;TZID=Pacific/Auckland:20240929T030000".into()),
+            (
+                "",
+                DTStartProperty {
+                    params: DTStartPropertyParams {
+                        value_type: None,
+                        tzid: Some(Tzid(Tz::Pacific__Auckland)),
+                        other: HashMap::new(),
+                    },
+                    date_time: DateTime::LocalDateTime(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2024_i32, 9_u32, 29_u32).unwrap(),
+                            NaiveTime::from_hms_opt(3_u32, 0_u32, 0_u32).unwrap(),
+                        )
+                    ),
+                },
+            ),
+        );
     }
 
     #[test]

--- a/redical_ical/src/properties/event/exdate.rs
+++ b/redical_ical/src/properties/event/exdate.rs
@@ -403,7 +403,7 @@ mod tests {
             ExDateProperty::parse_ical("EXDATE;TZID=Pacific/Auckland:20240929T020000".into()),
             nom::Err::Failure(
                 span: ";TZID=Pacific/Auckland:20240929T020000",
-                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"EXDATE;TZID=Pacific/Auckland:20240929T020000\"",
+                message: "Error - detected timezone aware datetime within a DST transition gap (supply this as UTC or fully DST adjusted) at \"EXDATE;TZID=Pacific/Auckland:20240929T020000\"",
                 context: ["EXDATE"],
             ),
         );

--- a/redical_ical/src/properties/event/exdate.rs
+++ b/redical_ical/src/properties/event/exdate.rs
@@ -397,7 +397,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_ical_wth_impossible_tz_date_time() {
+    fn parse_ical_wth_tz_dst_gap_date_time() {
         // Assert impossible date/time fails validation.
         assert_parser_error!(
             ExDateProperty::parse_ical("EXDATE;TZID=Pacific/Auckland:20240929T020000".into()),

--- a/redical_ical/src/properties/event/rdate.rs
+++ b/redical_ical/src/properties/event/rdate.rs
@@ -4,7 +4,7 @@ use nom::error::context;
 use nom::branch::alt;
 use nom::sequence::{pair, preceded};
 use nom::multi::separated_list1;
-use nom::combinator::{recognize, map, cut, opt};
+use nom::combinator::{recognize, map, map_res, cut, opt};
 
 use crate::values::date_time::{DateTime, ValueType};
 use crate::values::tzid::Tzid;
@@ -16,7 +16,7 @@ use crate::properties::{ICalendarProperty, ICalendarPropertyParams, ICalendarDat
 
 use crate::content_line::{ContentLineParams, ContentLine};
 
-use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, impl_icalendar_entity_traits};
+use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, ParserError, impl_icalendar_entity_traits};
 
 use std::collections::HashMap;
 
@@ -197,7 +197,7 @@ impl ICalendarEntity for RDateProperty {
             preceded(
                 tag("RDATE"),
                 cut(
-                    map(
+                    map_res(
                         pair(
                             opt(RDatePropertyParams::parse_ical),
                             preceded(
@@ -209,10 +209,19 @@ impl ICalendarEntity for RDateProperty {
                             ),
                         ),
                         |(params, date_times)| {
-                            RDateProperty {
-                                params: params.unwrap_or(RDatePropertyParams::default()),
-                                date_times,
+                            let r_date_property =
+                                RDateProperty {
+                                    params: params.unwrap_or(RDatePropertyParams::default()),
+                                    date_times,
+                                };
+
+                            if let Err(error) = ICalendarEntity::validate(&r_date_property) {
+                                return Err(
+                                    ParserError::new(error, input)
+                                );
                             }
+
+                            Ok(r_date_property)
                         }
                     )
                 )
@@ -231,6 +240,10 @@ impl ICalendarEntity for RDateProperty {
 
         if let Some(tzid) = self.params.tzid.as_ref() {
             tzid.validate()?;
+
+            for date_time in self.date_times.iter() {
+                tzid.validate_with_datetime_value(date_time)?;
+            }
         };
 
         if let Some(value_type) = self.params.value_type.as_ref() {
@@ -292,7 +305,7 @@ mod tests {
     use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     use chrono_tz::Tz;
 
-    use crate::tests::assert_parser_output;
+    use crate::tests::{assert_parser_output, assert_parser_error};
 
     #[test]
     fn parse_ical() {
@@ -389,6 +402,64 @@ mod tests {
         );
 
         assert!(RDateProperty::parse_ical(":".into()).is_err());
+    }
+
+    #[test]
+    fn parse_ical_wth_impossible_tz_date_time() {
+        // Assert impossible date/time fails validation.
+        assert_parser_error!(
+            RDateProperty::parse_ical("RDATE;TZID=Pacific/Auckland:20240929T020000".into()),
+            nom::Err::Failure(
+                span: ";TZID=Pacific/Auckland:20240929T020000",
+                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"RDATE;TZID=Pacific/Auckland:20240929T020000\"",
+                context: ["RDATE"],
+            ),
+        );
+
+        // Assert possible date/time does not fail validation.
+        assert_parser_output!(
+            RDateProperty::parse_ical("RDATE;TZID=Pacific/Auckland:20240929T010000".into()),
+            (
+                "",
+                RDateProperty {
+                    params: RDatePropertyParams {
+                        value_type: None,
+                        tzid: Some(Tzid(Tz::Pacific__Auckland)),
+                        other: HashMap::new(),
+                    },
+                    date_times: vec![
+                        DateTime::LocalDateTime(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2024_i32, 9_u32, 29_u32).unwrap(),
+                                NaiveTime::from_hms_opt(1_u32, 0_u32, 0_u32).unwrap(),
+                            )
+                        ),
+                    ].into(),
+                },
+            ),
+        );
+
+        assert_parser_output!(
+            RDateProperty::parse_ical("RDATE;TZID=Pacific/Auckland:20240929T030000".into()),
+            (
+                "",
+                RDateProperty {
+                    params: RDatePropertyParams {
+                        value_type: None,
+                        tzid: Some(Tzid(Tz::Pacific__Auckland)),
+                        other: HashMap::new(),
+                    },
+                    date_times: vec![
+                        DateTime::LocalDateTime(
+                            NaiveDateTime::new(
+                                NaiveDate::from_ymd_opt(2024_i32, 9_u32, 29_u32).unwrap(),
+                                NaiveTime::from_hms_opt(3_u32, 0_u32, 0_u32).unwrap(),
+                            )
+                        ),
+                    ].into(),
+                },
+            ),
+        );
     }
 
     #[test]

--- a/redical_ical/src/properties/event/rdate.rs
+++ b/redical_ical/src/properties/event/rdate.rs
@@ -405,7 +405,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_ical_wth_impossible_tz_date_time() {
+    fn parse_ical_wth_tz_dst_gap_date_time() {
         // Assert impossible date/time fails validation.
         assert_parser_error!(
             RDateProperty::parse_ical("RDATE;TZID=Pacific/Auckland:20240929T020000".into()),

--- a/redical_ical/src/properties/event/rdate.rs
+++ b/redical_ical/src/properties/event/rdate.rs
@@ -411,7 +411,7 @@ mod tests {
             RDateProperty::parse_ical("RDATE;TZID=Pacific/Auckland:20240929T020000".into()),
             nom::Err::Failure(
                 span: ";TZID=Pacific/Auckland:20240929T020000",
-                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"RDATE;TZID=Pacific/Auckland:20240929T020000\"",
+                message: "Error - detected timezone aware datetime within a DST transition gap (supply this as UTC or fully DST adjusted) at \"RDATE;TZID=Pacific/Auckland:20240929T020000\"",
                 context: ["RDATE"],
             ),
         );

--- a/redical_ical/src/properties/query/x_from.rs
+++ b/redical_ical/src/properties/query/x_from.rs
@@ -1,6 +1,6 @@
 use nom::error::context;
 use nom::sequence::{pair, preceded};
-use nom::combinator::{map, cut, opt};
+use nom::combinator::{map_res, cut, opt};
 
 use crate::values::date_time::{DateTime, ValueType};
 use crate::values::tzid::Tzid;
@@ -13,7 +13,7 @@ use crate::properties::{ICalendarProperty, ICalendarPropertyParams, ICalendarDat
 
 use crate::content_line::{ContentLineParams, ContentLine};
 
-use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, impl_icalendar_entity_traits};
+use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, ParserError, impl_icalendar_entity_traits};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct XFromPropertyParams {
@@ -146,16 +146,27 @@ impl ICalendarEntity for XFromProperty {
             preceded(
                 tag("X-FROM"),
                 cut(
-                    map(
+                    map_res(
                         pair(
                             opt(XFromPropertyParams::parse_ical),
                             preceded(colon, DateTime::parse_ical),
                         ),
                         |(params, date_time)| {
-                            XFromProperty {
-                                params: params.unwrap_or(XFromPropertyParams::default()),
-                                date_time,
+                            let x_from_property =
+                                XFromProperty {
+                                    params: params.unwrap_or(XFromPropertyParams::default()),
+                                    date_time,
+                                };
+
+                            if let Err(error) = ICalendarEntity::validate(&x_from_property) {
+                                return Err(
+                                    ParserError::new(error, input)
+                                );
                             }
+
+                            Ok(
+                                x_from_property
+                            )
                         }
                     )
                 )
@@ -172,6 +183,8 @@ impl ICalendarEntity for XFromProperty {
 
         if let Some(tzid) = self.params.tzid.as_ref() {
             tzid.validate()?;
+
+            tzid.validate_with_datetime_value(&self.date_time)?;
         };
 
         Ok(())
@@ -219,7 +232,7 @@ mod tests {
     use chrono::{NaiveDate, NaiveTime, NaiveDateTime};
     use chrono_tz::Tz;
 
-    use crate::tests::assert_parser_output;
+    use crate::tests::{assert_parser_output, assert_parser_error};
 
     #[test]
     fn parse_ical() {
@@ -277,6 +290,60 @@ mod tests {
         );
 
         assert!(XFromProperty::parse_ical(":".into()).is_err());
+    }
+
+    #[test]
+    fn parse_ical_wth_impossible_tz_date_time() {
+        // Assert impossible date/time fails validation.
+        assert_parser_error!(
+            XFromProperty::parse_ical("X-FROM;TZID=Pacific/Auckland:20240929T020000".into()),
+            nom::Err::Failure(
+                span: ";TZID=Pacific/Auckland:20240929T020000",
+                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"X-FROM;TZID=Pacific/Auckland:20240929T020000\"",
+                context: ["X-FROM"],
+            ),
+        );
+
+        // Assert possible date/time does not fail validation.
+        assert_parser_output!(
+            XFromProperty::parse_ical("X-FROM;TZID=Pacific/Auckland:20240929T010000".into()),
+            (
+                "",
+                XFromProperty {
+                    params: XFromPropertyParams {
+                        prop: WhereRangeProperty::DTStart,
+                        op: WhereFromRangeOperator::GreaterThan,
+                        tzid: Some(Tzid(Tz::Pacific__Auckland)),
+                    },
+                    date_time: DateTime::LocalDateTime(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2024_i32, 9_u32, 29_u32).unwrap(),
+                            NaiveTime::from_hms_opt(1_u32, 0_u32, 0_u32).unwrap(),
+                        )
+                    ),
+                },
+            ),
+        );
+
+        assert_parser_output!(
+            XFromProperty::parse_ical("X-FROM;TZID=Pacific/Auckland:20240929T030000".into()),
+            (
+                "",
+                XFromProperty {
+                    params: XFromPropertyParams {
+                        prop: WhereRangeProperty::DTStart,
+                        op: WhereFromRangeOperator::GreaterThan,
+                        tzid: Some(Tzid(Tz::Pacific__Auckland)),
+                    },
+                    date_time: DateTime::LocalDateTime(
+                        NaiveDateTime::new(
+                            NaiveDate::from_ymd_opt(2024_i32, 9_u32, 29_u32).unwrap(),
+                            NaiveTime::from_hms_opt(3_u32, 0_u32, 0_u32).unwrap(),
+                        )
+                    ),
+                },
+            ),
+        );
     }
 
     #[test]

--- a/redical_ical/src/properties/query/x_from.rs
+++ b/redical_ical/src/properties/query/x_from.rs
@@ -299,7 +299,7 @@ mod tests {
             XFromProperty::parse_ical("X-FROM;TZID=Pacific/Auckland:20240929T020000".into()),
             nom::Err::Failure(
                 span: ";TZID=Pacific/Auckland:20240929T020000",
-                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"X-FROM;TZID=Pacific/Auckland:20240929T020000\"",
+                message: "Error - detected timezone aware datetime within a DST transition gap (supply this as UTC or fully DST adjusted) at \"X-FROM;TZID=Pacific/Auckland:20240929T020000\"",
                 context: ["X-FROM"],
             ),
         );

--- a/redical_ical/src/properties/query/x_from.rs
+++ b/redical_ical/src/properties/query/x_from.rs
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_ical_wth_impossible_tz_date_time() {
+    fn parse_ical_wth_tz_dst_gap_date_time() {
         // Assert impossible date/time fails validation.
         assert_parser_error!(
             XFromProperty::parse_ical("X-FROM;TZID=Pacific/Auckland:20240929T020000".into()),

--- a/redical_ical/src/properties/query/x_until.rs
+++ b/redical_ical/src/properties/query/x_until.rs
@@ -299,7 +299,7 @@ mod tests {
             XUntilProperty::parse_ical("X-UNTIL;TZID=Pacific/Auckland:20240929T020000".into()),
             nom::Err::Failure(
                 span: ";TZID=Pacific/Auckland:20240929T020000",
-                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"X-UNTIL;TZID=Pacific/Auckland:20240929T020000\"",
+                message: "Error - detected timezone aware datetime within a DST transition gap (supply this as UTC or fully DST adjusted) at \"X-UNTIL;TZID=Pacific/Auckland:20240929T020000\"",
                 context: ["X-UNTIL"],
             ),
         );

--- a/redical_ical/src/properties/query/x_until.rs
+++ b/redical_ical/src/properties/query/x_until.rs
@@ -293,7 +293,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_ical_wth_impossible_tz_date_time() {
+    fn parse_ical_wth_tz_dst_gap_date_time() {
         // Assert impossible date/time fails validation.
         assert_parser_error!(
             XUntilProperty::parse_ical("X-UNTIL;TZID=Pacific/Auckland:20240929T020000".into()),

--- a/redical_ical/src/properties/recurrence_id.rs
+++ b/redical_ical/src/properties/recurrence_id.rs
@@ -368,7 +368,7 @@ mod tests {
     }
 
     #[test]
-    fn parse_ical_wth_impossible_tz_date_time() {
+    fn parse_ical_wth_tz_dst_gap_date_time() {
         // Assert impossible date/time fails validation.
         assert_parser_error!(
             RecurrenceIDProperty::parse_ical("RECURRENCE-ID;TZID=Pacific/Auckland:20240929T020000".into()),

--- a/redical_ical/src/properties/recurrence_id.rs
+++ b/redical_ical/src/properties/recurrence_id.rs
@@ -386,7 +386,7 @@ mod tests {
                 "",
                 RecurrenceIDProperty {
                     params: RecurrenceIDPropertyParams {
-                        value_type: None,
+                        value_type: Some(ValueType::DateTime),
                         tzid: Some(Tzid(Tz::Pacific__Auckland)),
                         other: HashMap::new(),
                     },
@@ -406,7 +406,7 @@ mod tests {
                 "",
                 RecurrenceIDProperty {
                     params: RecurrenceIDPropertyParams {
-                        value_type: None,
+                        value_type: Some(ValueType::DateTime),
                         tzid: Some(Tzid(Tz::Pacific__Auckland)),
                         other: HashMap::new(),
                     },

--- a/redical_ical/src/properties/recurrence_id.rs
+++ b/redical_ical/src/properties/recurrence_id.rs
@@ -374,7 +374,7 @@ mod tests {
             RecurrenceIDProperty::parse_ical("RECURRENCE-ID;TZID=Pacific/Auckland:20240929T020000".into()),
             nom::Err::Failure(
                 span: ";TZID=Pacific/Auckland:20240929T020000",
-                message: "Error - invalid date time with timezone (possibly daylight savings threshold) at \"RECURRENCE-ID;TZID=Pacific/Auckland:20240929T\"",
+                message: "Error - detected timezone aware datetime within a DST transition gap (supply this as UTC or fully DST adjusted) at \"RECURRENCE-ID;TZID=Pacific/Auckland:20240929T\"",
                 context: ["RECURRENCE-ID"],
             ),
         );

--- a/redical_ical/src/values/date_time.rs
+++ b/redical_ical/src/values/date_time.rs
@@ -285,6 +285,24 @@ impl DateTime {
 
 }
 
+impl From<&DateTime> for NaiveDateTime {
+    fn from(date_time: &DateTime) -> Self {
+        match date_time {
+            DateTime::LocalDate(date) => {
+                NaiveDateTime::from(date.to_owned())
+            },
+
+            DateTime::LocalDateTime(date_time) => {
+                date_time.to_owned()
+            },
+
+            DateTime::UtcDateTime(date_time) => {
+                date_time.to_owned()
+            },
+        }
+    }
+}
+
 impl From<i64> for DateTime {
     fn from(timestamp: i64) -> Self {
         match Tz::UTC.timestamp_opt(timestamp, 0) {

--- a/redical_ical/src/values/tzid.rs
+++ b/redical_ical/src/values/tzid.rs
@@ -99,6 +99,166 @@ mod tests {
                 context: ["TZID"],
             )
         );
+
+        macro_rules! assert_tzid_parser_output {
+            ($timezone_identifier:expr, $expected_tz:expr $(,)*) => {
+                assert_parser_output!(
+                    Tzid::parse_ical($timezone_identifier.into()),
+                    (
+                        "",
+                        Tzid($expected_tz),
+                    )
+                );
+            }
+        }
+
+        assert_tzid_parser_output!("Africa/Algiers", Tz::Africa__Algiers);
+        assert_tzid_parser_output!("Africa/Cairo", Tz::Africa__Cairo);
+        assert_tzid_parser_output!("Africa/Casablanca", Tz::Africa__Casablanca);
+        assert_tzid_parser_output!("Africa/Harare", Tz::Africa__Harare);
+        assert_tzid_parser_output!("Africa/Johannesburg", Tz::Africa__Johannesburg);
+        assert_tzid_parser_output!("Africa/Monrovia", Tz::Africa__Monrovia);
+        assert_tzid_parser_output!("Africa/Nairobi", Tz::Africa__Nairobi);
+        assert_tzid_parser_output!("America/Antigua", Tz::America__Antigua);
+        assert_tzid_parser_output!("America/Argentina/Buenos_Aires", Tz::America__Argentina__Buenos_Aires);
+        assert_tzid_parser_output!("America/Bogota", Tz::America__Bogota);
+        assert_tzid_parser_output!("America/Caracas", Tz::America__Caracas);
+        assert_tzid_parser_output!("America/Chicago", Tz::America__Chicago);
+        assert_tzid_parser_output!("America/Chihuahua", Tz::America__Chihuahua);
+        assert_tzid_parser_output!("America/Denver", Tz::America__Denver);
+        assert_tzid_parser_output!("America/Godthab", Tz::America__Godthab);
+        assert_tzid_parser_output!("America/Guatemala", Tz::America__Guatemala);
+        assert_tzid_parser_output!("America/Guyana", Tz::America__Guyana);
+        assert_tzid_parser_output!("America/Halifax", Tz::America__Halifax);
+        assert_tzid_parser_output!("America/Indiana/Indianapolis", Tz::America__Indiana__Indianapolis);
+        assert_tzid_parser_output!("America/Juneau", Tz::America__Juneau);
+        assert_tzid_parser_output!("America/La_Paz", Tz::America__La_Paz);
+        assert_tzid_parser_output!("America/Lima", Tz::America__Lima);
+        assert_tzid_parser_output!("America/Los_Angeles", Tz::America__Los_Angeles);
+        assert_tzid_parser_output!("America/Mazatlan", Tz::America__Mazatlan);
+        assert_tzid_parser_output!("America/Mexico_City", Tz::America__Mexico_City);
+        assert_tzid_parser_output!("America/Monterrey", Tz::America__Monterrey);
+        assert_tzid_parser_output!("America/Montevideo", Tz::America__Montevideo);
+        assert_tzid_parser_output!("America/New_York", Tz::America__New_York);
+        assert_tzid_parser_output!("America/Phoenix", Tz::America__Phoenix);
+        assert_tzid_parser_output!("America/Puerto_Rico", Tz::America__Puerto_Rico);
+        assert_tzid_parser_output!("America/Regina", Tz::America__Regina);
+        assert_tzid_parser_output!("America/Santiago", Tz::America__Santiago);
+        assert_tzid_parser_output!("America/Sao_Paulo", Tz::America__Sao_Paulo);
+        assert_tzid_parser_output!("America/St_Johns", Tz::America__St_Johns);
+        assert_tzid_parser_output!("America/Tijuana", Tz::America__Tijuana);
+        assert_tzid_parser_output!("America/Winnipeg", Tz::America__Winnipeg);
+        assert_tzid_parser_output!("Asia/Almaty", Tz::Asia__Almaty);
+        assert_tzid_parser_output!("Asia/Amman", Tz::Asia__Amman);
+        assert_tzid_parser_output!("Asia/Baghdad", Tz::Asia__Baghdad);
+        assert_tzid_parser_output!("Asia/Baku", Tz::Asia__Baku);
+        assert_tzid_parser_output!("Asia/Bangkok", Tz::Asia__Bangkok);
+        assert_tzid_parser_output!("Asia/Beirut", Tz::Asia__Beirut);
+        assert_tzid_parser_output!("Asia/Chongqing", Tz::Asia__Chongqing);
+        assert_tzid_parser_output!("Asia/Colombo", Tz::Asia__Colombo);
+        assert_tzid_parser_output!("Asia/Dhaka", Tz::Asia__Dhaka);
+        assert_tzid_parser_output!("Asia/Ho_Chi_Minh", Tz::Asia__Ho_Chi_Minh);
+        assert_tzid_parser_output!("Asia/Hong_Kong", Tz::Asia__Hong_Kong);
+        assert_tzid_parser_output!("Asia/Irkutsk", Tz::Asia__Irkutsk);
+        assert_tzid_parser_output!("Asia/Jakarta", Tz::Asia__Jakarta);
+        assert_tzid_parser_output!("Asia/Jerusalem", Tz::Asia__Jerusalem);
+        assert_tzid_parser_output!("Asia/Kabul", Tz::Asia__Kabul);
+        assert_tzid_parser_output!("Asia/Kamchatka", Tz::Asia__Kamchatka);
+        assert_tzid_parser_output!("Asia/Karachi", Tz::Asia__Karachi);
+        assert_tzid_parser_output!("Asia/Kathmandu", Tz::Asia__Kathmandu);
+        assert_tzid_parser_output!("Asia/Kolkata", Tz::Asia__Kolkata);
+        assert_tzid_parser_output!("Asia/Krasnoyarsk", Tz::Asia__Krasnoyarsk);
+        assert_tzid_parser_output!("Asia/Kuala_Lumpur", Tz::Asia__Kuala_Lumpur);
+        assert_tzid_parser_output!("Asia/Kuwait", Tz::Asia__Kuwait);
+        assert_tzid_parser_output!("Asia/Magadan", Tz::Asia__Magadan);
+        assert_tzid_parser_output!("Asia/Manila", Tz::Asia__Manila);
+        assert_tzid_parser_output!("Asia/Muscat", Tz::Asia__Muscat);
+        assert_tzid_parser_output!("Asia/Novosibirsk", Tz::Asia__Novosibirsk);
+        assert_tzid_parser_output!("Asia/Qatar", Tz::Asia__Qatar);
+        assert_tzid_parser_output!("Asia/Rangoon", Tz::Asia__Rangoon);
+        assert_tzid_parser_output!("Asia/Riyadh", Tz::Asia__Riyadh);
+        assert_tzid_parser_output!("Asia/Seoul", Tz::Asia__Seoul);
+        assert_tzid_parser_output!("Asia/Shanghai", Tz::Asia__Shanghai);
+        assert_tzid_parser_output!("Asia/Singapore", Tz::Asia__Singapore);
+        assert_tzid_parser_output!("Asia/Srednekolymsk", Tz::Asia__Srednekolymsk);
+        assert_tzid_parser_output!("Asia/Taipei", Tz::Asia__Taipei);
+        assert_tzid_parser_output!("Asia/Tashkent", Tz::Asia__Tashkent);
+        assert_tzid_parser_output!("Asia/Tbilisi", Tz::Asia__Tbilisi);
+        assert_tzid_parser_output!("Asia/Tehran", Tz::Asia__Tehran);
+        assert_tzid_parser_output!("Asia/Tokyo", Tz::Asia__Tokyo);
+        assert_tzid_parser_output!("Asia/Ulaanbaatar", Tz::Asia__Ulaanbaatar);
+        assert_tzid_parser_output!("Asia/Urumqi", Tz::Asia__Urumqi);
+        assert_tzid_parser_output!("Asia/Vladivostok", Tz::Asia__Vladivostok);
+        assert_tzid_parser_output!("Asia/Yakutsk", Tz::Asia__Yakutsk);
+        assert_tzid_parser_output!("Asia/Yekaterinburg", Tz::Asia__Yekaterinburg);
+        assert_tzid_parser_output!("Asia/Yerevan", Tz::Asia__Yerevan);
+        assert_tzid_parser_output!("Atlantic/Azores", Tz::Atlantic__Azores);
+        assert_tzid_parser_output!("Atlantic/Cape_Verde", Tz::Atlantic__Cape_Verde);
+        assert_tzid_parser_output!("Atlantic/South_Georgia", Tz::Atlantic__South_Georgia);
+        assert_tzid_parser_output!("Australia/Adelaide", Tz::Australia__Adelaide);
+        assert_tzid_parser_output!("Australia/Brisbane", Tz::Australia__Brisbane);
+        assert_tzid_parser_output!("Australia/Canberra", Tz::Australia__Canberra);
+        assert_tzid_parser_output!("Australia/Darwin", Tz::Australia__Darwin);
+        assert_tzid_parser_output!("Australia/Hobart", Tz::Australia__Hobart);
+        assert_tzid_parser_output!("Australia/Melbourne", Tz::Australia__Melbourne);
+        assert_tzid_parser_output!("Australia/NSW", Tz::Australia__NSW);
+        assert_tzid_parser_output!("Australia/Perth", Tz::Australia__Perth);
+        assert_tzid_parser_output!("Australia/Queensland", Tz::Australia__Queensland);
+        assert_tzid_parser_output!("Australia/Sydney", Tz::Australia__Sydney);
+        assert_tzid_parser_output!("CET", Tz::CET);
+        assert_tzid_parser_output!("Etc/GMT+12", Tz::Etc__GMTPlus12);
+        assert_tzid_parser_output!("Etc/UTC", Tz::Etc__UTC);
+        assert_tzid_parser_output!("Europe/Amsterdam", Tz::Europe__Amsterdam);
+        assert_tzid_parser_output!("Europe/Athens", Tz::Europe__Athens);
+        assert_tzid_parser_output!("Europe/Belgrade", Tz::Europe__Belgrade);
+        assert_tzid_parser_output!("Europe/Berlin", Tz::Europe__Berlin);
+        assert_tzid_parser_output!("Europe/Bratislava", Tz::Europe__Bratislava);
+        assert_tzid_parser_output!("Europe/Brussels", Tz::Europe__Brussels);
+        assert_tzid_parser_output!("Europe/Bucharest", Tz::Europe__Bucharest);
+        assert_tzid_parser_output!("Europe/Budapest", Tz::Europe__Budapest);
+        assert_tzid_parser_output!("Europe/Copenhagen", Tz::Europe__Copenhagen);
+        assert_tzid_parser_output!("Europe/Dublin", Tz::Europe__Dublin);
+        assert_tzid_parser_output!("Europe/Helsinki", Tz::Europe__Helsinki);
+        assert_tzid_parser_output!("Europe/Istanbul", Tz::Europe__Istanbul);
+        assert_tzid_parser_output!("Europe/Kaliningrad", Tz::Europe__Kaliningrad);
+        assert_tzid_parser_output!("Europe/Kiev", Tz::Europe__Kiev);
+        assert_tzid_parser_output!("Europe/Lisbon", Tz::Europe__Lisbon);
+        assert_tzid_parser_output!("Europe/Ljubljana", Tz::Europe__Ljubljana);
+        assert_tzid_parser_output!("Europe/London", Tz::Europe__London);
+        assert_tzid_parser_output!("Europe/Madrid", Tz::Europe__Madrid);
+        assert_tzid_parser_output!("Europe/Minsk", Tz::Europe__Minsk);
+        assert_tzid_parser_output!("Europe/Moscow", Tz::Europe__Moscow);
+        assert_tzid_parser_output!("Europe/Paris", Tz::Europe__Paris);
+        assert_tzid_parser_output!("Europe/Prague", Tz::Europe__Prague);
+        assert_tzid_parser_output!("Europe/Riga", Tz::Europe__Riga);
+        assert_tzid_parser_output!("Europe/Rome", Tz::Europe__Rome);
+        assert_tzid_parser_output!("Europe/Samara", Tz::Europe__Samara);
+        assert_tzid_parser_output!("Europe/Sarajevo", Tz::Europe__Sarajevo);
+        assert_tzid_parser_output!("Europe/Skopje", Tz::Europe__Skopje);
+        assert_tzid_parser_output!("Europe/Sofia", Tz::Europe__Sofia);
+        assert_tzid_parser_output!("Europe/Stockholm", Tz::Europe__Stockholm);
+        assert_tzid_parser_output!("Europe/Tallinn", Tz::Europe__Tallinn);
+        assert_tzid_parser_output!("Europe/Vienna", Tz::Europe__Vienna);
+        assert_tzid_parser_output!("Europe/Vilnius", Tz::Europe__Vilnius);
+        assert_tzid_parser_output!("Europe/Volgograd", Tz::Europe__Volgograd);
+        assert_tzid_parser_output!("Europe/Warsaw", Tz::Europe__Warsaw);
+        assert_tzid_parser_output!("Europe/Zagreb", Tz::Europe__Zagreb);
+        assert_tzid_parser_output!("Europe/Zurich", Tz::Europe__Zurich);
+        assert_tzid_parser_output!("GMT", Tz::GMT);
+        assert_tzid_parser_output!("Pacific/Apia", Tz::Pacific__Apia);
+        assert_tzid_parser_output!("Pacific/Auckland", Tz::Pacific__Auckland);
+        assert_tzid_parser_output!("Pacific/Chatham", Tz::Pacific__Chatham);
+        assert_tzid_parser_output!("Pacific/Fakaofo", Tz::Pacific__Fakaofo);
+        assert_tzid_parser_output!("Pacific/Fiji", Tz::Pacific__Fiji);
+        assert_tzid_parser_output!("Pacific/Guadalcanal", Tz::Pacific__Guadalcanal);
+        assert_tzid_parser_output!("Pacific/Guam", Tz::Pacific__Guam);
+        assert_tzid_parser_output!("Pacific/Honolulu", Tz::Pacific__Honolulu);
+        assert_tzid_parser_output!("Pacific/Majuro", Tz::Pacific__Majuro);
+        assert_tzid_parser_output!("Pacific/Midway", Tz::Pacific__Midway);
+        assert_tzid_parser_output!("Pacific/Noumea", Tz::Pacific__Noumea);
+        assert_tzid_parser_output!("Pacific/Pago_Pago", Tz::Pacific__Pago_Pago);
+        assert_tzid_parser_output!("Pacific/Port_Moresby", Tz::Pacific__Port_Moresby);
+        assert_tzid_parser_output!("Pacific/Tongatapu", Tz::Pacific__Tongatapu);
     }
 
     #[test]

--- a/redical_ical/src/values/tzid.rs
+++ b/redical_ical/src/values/tzid.rs
@@ -65,10 +65,15 @@ impl Tzid {
     /// * `Err(String)` with an error message if the `DateTime` is invalid, possibly due to
     ///   being on a daylight savings threshold.
     pub fn validate_with_datetime_value(&self, date_time: &DateTime) -> Result<(), String> {
+        // TODO: Watch chrono_tz crate for the release of the code in the following PR:
+        //       -  https://github.com/chronotope/chrono-tz/pull/188
+        //
+        //       Once released, implement better TZ DST gap handling instead of regarding as
+        //       invalid.
         match self.0.offset_from_local_datetime(&date_time.into()) {
             LocalResult::Single(_) => Ok(()),
 
-            _ => Err(String::from("invalid date time with timezone (possibly daylight savings threshold)")),
+            _ => Err(String::from("detected timezone aware datetime within a DST transition gap (supply this as UTC or fully DST adjusted)")),
         }
     }
 }

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1937,7 +1937,7 @@ mod integration {
         assert_eq!(redis::cmd("SAVE").query(connection), Ok(String::from("OK")));
 
         redis::cmd("FLUSHDB")
-            .query(connection)
+            .query::<()>(connection)
             .with_context(|| {
                 format!(
                     "failed to cleanup with FLUSHDB after running integration test function: {}", stringify!($test_function),
@@ -2072,6 +2072,7 @@ mod integration {
                 ],
             ],
         );
+
         Ok(())
     }
 
@@ -2158,7 +2159,12 @@ mod integration {
             assert_keyspace_events_published!(message_queue, []);
 
             // Assert error reporting Calendar querying disabled
-            let disabled_query_result: Result<Vec<String>, String> = redis::cmd("rdcl.evi_query").arg("TEST_CALENDAR_UID").arg("X-RELATED-TO;RELTYPE=PARENT:PARENT_UID").query(connection).map_err(|error| error.to_string());
+            let disabled_query_result: Result<Vec<String>, String> =
+                redis::cmd("rdcl.evi_query")
+                    .arg("TEST_CALENDAR_UID")
+                    .arg("X-RELATED-TO;RELTYPE=PARENT:PARENT_UID")
+                    .query(connection)
+                    .map_err(|error| error.to_string());
 
             assert_eq!(
                 disabled_query_result,
@@ -2337,12 +2343,15 @@ mod integration {
             ],
         );
 
-        assert_eq!(redis::cmd("SAVE").query(connection), Ok(String::from("OK")));
+        assert_eq!(
+            redis::cmd("SAVE").query(connection),
+            Ok(String::from("OK")),
+        );
 
         // std::thread::sleep(std::time::Duration::from_secs(5));
 
         redis::cmd("FLUSHDB")
-            .query(connection)
+            .query::<()>(connection)
             .with_context(|| {
                 format!(
                     "failed to cleanup with FLUSHDB after running integration test function: {}", stringify!($test_function),
@@ -2515,7 +2524,7 @@ mod integration {
                     .arg("TEST_CALENDAR_UID")
                     .arg("EVENT_IN_OXFORD_MON_WED")
                     .arg(
-                        &[
+                        [
                             "SUMMARY:Event in Oxford on Mondays and Wednesdays at 5:00PM",
                             "RRULE:BYDAY=MO,WE;COUNT=3;FREQ=WEEKLY;INTERVAL=1",
                             "DTSTART:20201231T170000Z",
@@ -2549,7 +2558,7 @@ mod integration {
                     .arg("EVENT_IN_OXFORD_MON_WED")
                     .arg("20210102T170000Z")
                     .arg(
-                        &[
+                        [
                             "SUMMARY:Event in Oxford on Mondays and Wednesdays at 5:00PM (OVERRIDDEN)",
                             "DESCRIPTION:Overridden event description - this should be not be present in the base event.",
                             "LAST-MODIFIED:20210501T090000Z",
@@ -2572,7 +2581,7 @@ mod integration {
                 redis::cmd("rdcl.evi_query")
                     .arg("TEST_CALENDAR_UID")
                     .arg(
-                        &[
+                        [
                             "X-FROM;PROP=DTSTART;OP=GT;TZID=Europe/London:20210105T180000Z",
                             "X-UNTIL;PROP=DTSTART;OP=LTE;TZID=UTC:20210630T180000Z",
                             "X-GEO;DIST=105.5KM:51.55577390;-1.77971760",
@@ -2619,5 +2628,4 @@ mod integration {
         test_key_expire_eviction_keyspace_events,
         test_redical_ical_parser_timeout_ms_config,
     );
-
 }

--- a/tests/macros.rs
+++ b/tests/macros.rs
@@ -1143,7 +1143,7 @@ macro_rules! run_all_integration_tests_sequentially {
                 $test_function(&mut connection)?;
 
                 redis::cmd("FLUSHDB")
-                    .query(&mut connection)
+                    .query::<()>(&mut connection)
                     .with_context(|| {
                         format!(
                             "failed to cleanup with FLUSHDB after running integration test function: {}", stringify!($test_function),


### PR DESCRIPTION
This PR resolves a crash when a date time property with a timezone specified and a date string within a DST transition is parsed. The current strategy is to validate against this and prompt the client to resubmit the property as either `UTC` or adjusted DST adjusted.

An example of this would be `DTSTART;TZID=Pacific/Auckland:20240929T020000` which does not really exist as it's DST transitions to `DTSTART;TZID=Pacific/Auckland:20240929T030000`.

In the future we can handle this better by making an assumption about the DST gap end time to proceed with. Ideally we  we could lean on the `chrono_tz` `GapInfo` facility introduced by this PR (https://github.com/chronotope/chrono-tz/pull/188). Unfortunately this has not been included in a release yet and in an effort to keep things simple and stable for now we will proceed with this the validation strategy as we iron out other creases within the RediCal module.