### PR TITLE
Implement Negative Query property parsing

### DIFF
--- a/redical_ical/src/properties/query/where_properties_group.rs
+++ b/redical_ical/src/properties/query/where_properties_group.rs
@@ -277,6 +277,7 @@ mod tests {
                             XClassProperty {
                                 params: XClassPropertyParams::default(),
                                 classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                                negated: false,
                             },
                         ),
                     ]
@@ -295,6 +296,7 @@ mod tests {
                             XClassProperty {
                                 params: XClassPropertyParams::default(),
                                 classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                                negated: false,
                             },
                         ),
                         GroupedWhereProperty::XCategories(
@@ -302,6 +304,7 @@ mod tests {
                             XCategoriesProperty {
                                 params: XCategoriesPropertyParams::default(),
                                 categories: List::from(vec![Text(String::from("APPOINTMENT")), Text(String::from("EDUCATION"))]),
+                                negated: false,
                             },
                         ),
                     ]
@@ -320,6 +323,7 @@ mod tests {
                             XClassProperty {
                                 params: XClassPropertyParams::default(),
                                 classes: List::from(vec![ClassValue::Public]),
+                                negated: false,
                             },
                         ),
                         GroupedWhereProperty::XCategories(
@@ -327,6 +331,7 @@ mod tests {
                             XCategoriesProperty {
                                 params: XCategoriesPropertyParams::default(),
                                 categories: List::from(vec![Text(String::from("APPOINTMENT"))]),
+                                negated: false,
                             },
                         ),
                         GroupedWhereProperty::WherePropertiesGroup(
@@ -338,6 +343,7 @@ mod tests {
                                         XClassProperty {
                                             params: XClassPropertyParams::default(),
                                             classes: List::from(vec![ClassValue::Private]),
+                                            negated: false,
                                         },
                                     ),
                                     GroupedWhereProperty::XCategories(
@@ -345,6 +351,7 @@ mod tests {
                                         XCategoriesProperty {
                                             params: XCategoriesPropertyParams::default(),
                                             categories: List::from(vec![Text(String::from("EDUCATION"))]),
+                                            negated: false,
                                         },
                                     ),
                                 ]
@@ -366,6 +373,7 @@ mod tests {
                             XClassProperty {
                                 params: XClassPropertyParams::default(),
                                 classes: List::from(vec![ClassValue::Public]),
+                                negated: false,
                             },
                         ),
                         GroupedWhereProperty::XCategories(
@@ -373,6 +381,7 @@ mod tests {
                             XCategoriesProperty {
                                 params: XCategoriesPropertyParams::default(),
                                 categories: List::from(vec![Text(String::from("APPOINTMENT"))]),
+                                negated: false,
                             },
                         ),
                         GroupedWhereProperty::WherePropertiesGroup(
@@ -384,6 +393,7 @@ mod tests {
                                         XClassProperty {
                                             params: XClassPropertyParams::default(),
                                             classes: List::from(vec![ClassValue::Private]),
+                                            negated: false,
                                         },
                                     ),
                                     GroupedWhereProperty::XLocationType(
@@ -391,6 +401,7 @@ mod tests {
                                         XLocationTypeProperty {
                                             params: XLocationTypePropertyParams::default(),
                                             types: List::from(vec![Text(String::from("ONLINE")), Text(String::from("ZOOM"))]),
+                                            negated: false,
                                         },
                                     ),
                                 ]
@@ -420,6 +431,7 @@ mod tests {
                         XClassProperty {
                             params: XClassPropertyParams::default(),
                             classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                            negated: false,
                         },
                     ),
                 ]
@@ -435,6 +447,7 @@ mod tests {
                         XClassProperty {
                             params: XClassPropertyParams::default(),
                             classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                            negated: false,
                         },
                     ),
                     GroupedWhereProperty::XCategories(
@@ -442,6 +455,7 @@ mod tests {
                         XCategoriesProperty {
                             params: XCategoriesPropertyParams::default(),
                             categories: List::from(vec![Text(String::from("APPOINTMENT")), Text(String::from("EDUCATION"))]),
+                            negated: false,
                         },
                     ),
                 ]
@@ -457,6 +471,7 @@ mod tests {
                         XClassProperty {
                             params: XClassPropertyParams::default(),
                             classes: List::from(vec![ClassValue::Public]),
+                            negated: false,
                         },
                     ),
                     GroupedWhereProperty::XCategories(
@@ -464,6 +479,7 @@ mod tests {
                         XCategoriesProperty {
                             params: XCategoriesPropertyParams::default(),
                             categories: List::from(vec![Text(String::from("APPOINTMENT"))]),
+                            negated: false,
                         },
                     ),
                     GroupedWhereProperty::WherePropertiesGroup(
@@ -475,6 +491,7 @@ mod tests {
                                     XClassProperty {
                                         params: XClassPropertyParams::default(),
                                         classes: List::from(vec![ClassValue::Private]),
+                                        negated: false,
                                     },
                                 ),
                                 GroupedWhereProperty::XCategories(
@@ -482,6 +499,7 @@ mod tests {
                                     XCategoriesProperty {
                                         params: XCategoriesPropertyParams::default(),
                                         categories: List::from(vec![Text(String::from("EDUCATION"))]),
+                                        negated: false,
                                     },
                                 ),
                             ]
@@ -500,6 +518,7 @@ mod tests {
                         XClassProperty {
                             params: XClassPropertyParams::default(),
                             classes: List::from(vec![ClassValue::Public]),
+                            negated: false,
                         },
                     ),
                     GroupedWhereProperty::XCategories(
@@ -507,6 +526,7 @@ mod tests {
                         XCategoriesProperty {
                             params: XCategoriesPropertyParams::default(),
                             categories: List::from(vec![Text(String::from("APPOINTMENT"))]),
+                            negated: false,
                         },
                     ),
                     GroupedWhereProperty::WherePropertiesGroup(
@@ -518,12 +538,14 @@ mod tests {
                                     XClassProperty {
                                         params: XClassPropertyParams::default(),
                                         classes: List::from(vec![ClassValue::Private]),
+                                        negated: false,
                                     },
                                 ),
                                 GroupedWhereProperty::XUID(
                                     Some(WhereOperator::Or),
                                     XUIDProperty {
                                         uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
+                                        negated: false,
                                     },
                                 ),
                             ]

--- a/redical_ical/src/properties/query/x_categories.rs
+++ b/redical_ical/src/properties/query/x_categories.rs
@@ -71,6 +71,7 @@ impl Default for XCategoriesPropertyParams {
 pub struct XCategoriesProperty {
     pub params: XCategoriesPropertyParams,
     pub categories: List<Text>,
+    pub negated: bool,
 }
 
 impl ICalendarEntity for XCategoriesProperty {
@@ -89,6 +90,7 @@ impl ICalendarEntity for XCategoriesProperty {
                             XCategoriesProperty {
                                 params: params.unwrap_or(XCategoriesPropertyParams::default()),
                                 categories,
+                                negated: false,
                             }
                         }
                     )
@@ -150,6 +152,7 @@ mod tests {
                 XCategoriesProperty {
                     params: XCategoriesPropertyParams { op: WhereOperator::And },
                     categories: List::from(vec![Text(String::from("APPOINTMENT")), Text(String::from("EDUCATION"))]),
+                    negated: false,
                 },
             ),
         );
@@ -161,6 +164,7 @@ mod tests {
                 XCategoriesProperty {
                     params: XCategoriesPropertyParams { op: WhereOperator::And },
                     categories: List::from(vec![Text(String::from("APPOINTMENT")), Text(String::from("EDUCATION"))]),
+                    negated: false,
                 },
             ),
         );
@@ -172,6 +176,7 @@ mod tests {
                 XCategoriesProperty {
                     params: XCategoriesPropertyParams { op: WhereOperator::Or },
                     categories: List::from(vec![Text(String::from("APPOINTMENT")), Text(String::from("EDUCATION"))]),
+                    negated: false,
                 },
             ),
         );
@@ -186,6 +191,7 @@ mod tests {
             XCategoriesProperty {
                 params: XCategoriesPropertyParams { op: WhereOperator::And },
                 categories: List::from(vec![Text(String::from("APPOINTMENT")), Text(String::from("EDUCATION"))]),
+                negated: false,
             }.render_ical(),
             String::from("X-CATEGORIES;OP=AND:APPOINTMENT,EDUCATION"),
         );
@@ -194,6 +200,7 @@ mod tests {
             XCategoriesProperty {
                 params: XCategoriesPropertyParams { op: WhereOperator::Or },
                 categories: List::from(vec![Text(String::from("APPOINTMENT")), Text(String::from("EDUCATION"))]),
+                negated: false,
             }.render_ical(),
             String::from("X-CATEGORIES;OP=OR:APPOINTMENT,EDUCATION"),
         );

--- a/redical_ical/src/properties/query/x_class.rs
+++ b/redical_ical/src/properties/query/x_class.rs
@@ -72,6 +72,7 @@ impl Default for XClassPropertyParams {
 pub struct XClassProperty {
     pub params: XClassPropertyParams,
     pub classes: List<ClassValue>,
+    pub negated: bool,
 }
 
 impl ICalendarEntity for XClassProperty {
@@ -90,6 +91,7 @@ impl ICalendarEntity for XClassProperty {
                             XClassProperty {
                                 params: params.unwrap_or(XClassPropertyParams::default()),
                                 classes,
+                                negated: false,
                             }
                         }
                     )
@@ -149,6 +151,7 @@ mod tests {
                 XClassProperty {
                     params: XClassPropertyParams { op: WhereOperator::And },
                     classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                    negated: false,
                 },
             ),
         );
@@ -160,6 +163,7 @@ mod tests {
                 XClassProperty {
                     params: XClassPropertyParams { op: WhereOperator::And },
                     classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                    negated: false,
                 },
             ),
         );
@@ -171,6 +175,7 @@ mod tests {
                 XClassProperty {
                     params: XClassPropertyParams { op: WhereOperator::Or },
                     classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                    negated: false,
                 },
             ),
         );
@@ -185,6 +190,7 @@ mod tests {
             XClassProperty {
                 params: XClassPropertyParams { op: WhereOperator::And },
                 classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                negated: false,
             }.render_ical(),
             String::from("X-CLASS;OP=AND:PRIVATE,PUBLIC"),
         );
@@ -193,6 +199,7 @@ mod tests {
             XClassProperty {
                 params: XClassPropertyParams { op: WhereOperator::Or },
                 classes: List::from(vec![ClassValue::Public, ClassValue::Private]),
+                negated: false,
             }.render_ical(),
             String::from("X-CLASS;OP=OR:PRIVATE,PUBLIC"),
         );

--- a/redical_ical/src/properties/query/x_geo.rs
+++ b/redical_ical/src/properties/query/x_geo.rs
@@ -94,6 +94,7 @@ pub struct XGeoProperty {
     pub params: XGeoPropertyParams,
     pub latitude: Float,
     pub longitude: Float,
+    pub negated: bool,
 }
 
 impl ICalendarEntity for XGeoProperty {
@@ -116,6 +117,7 @@ impl ICalendarEntity for XGeoProperty {
                                 params: params.unwrap_or(XGeoPropertyParams::default()),
                                 latitude,
                                 longitude,
+                                negated: false,
                             }
                         }
                     )
@@ -181,6 +183,7 @@ mod tests {
                     params: XGeoPropertyParams { dist: DistValue::Kilometers(Float(10.0_f64)) },
                     latitude: Float(48.85299_f64),
                     longitude: Float(2.36885_f64),
+                    negated: false,
                 },
             ),
         );
@@ -193,6 +196,7 @@ mod tests {
                     params: XGeoPropertyParams { dist: DistValue::Kilometers(Float(1.5_f64)) },
                     latitude: Float(48.85299_f64),
                     longitude: Float(2.36885_f64),
+                    negated: false,
                 },
             ),
         );
@@ -205,6 +209,7 @@ mod tests {
                     params: XGeoPropertyParams { dist: DistValue::Miles(Float(30.0_f64)) },
                     latitude: Float(48.85299_f64),
                     longitude: Float(2.36885_f64),
+                    negated: false,
                 },
             ),
         );
@@ -219,6 +224,7 @@ mod tests {
                 params: XGeoPropertyParams { dist: DistValue::Kilometers(Float(1.5_f64)) },
                 latitude: Float(48.85299_f64),
                 longitude: Float(2.36885_f64),
+                negated: false,
             }.render_ical(),
             String::from("X-GEO;DIST=1.5KM:48.85299;2.36885"),
         );
@@ -228,6 +234,7 @@ mod tests {
                 params: XGeoPropertyParams { dist: DistValue::Miles(Float(30.0_f64)) },
                 latitude: Float(48.85299_f64),
                 longitude: Float(2.36885_f64),
+                negated: false,
             }.render_ical(),
             String::from("X-GEO;DIST=30MI:48.85299;2.36885"),
         );

--- a/redical_ical/src/properties/query/x_geo.rs
+++ b/redical_ical/src/properties/query/x_geo.rs
@@ -89,6 +89,11 @@ impl ICalendarPropertyParams for XGeoPropertyParams {
 ///
 /// X-GEO;DIST=1.5KM:48.85299;2.36885
 /// X-GEO;DIST=30MI:48.85299;2.36885
+///
+/// Negated:
+///
+/// X-GEO-NOT;DIST=1.5KM:48.85299;2.36885
+/// X-GEO-NOT;DIST=30MI:48.85299;2.36885
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct XGeoProperty {
     pub params: XGeoPropertyParams,
@@ -105,19 +110,22 @@ impl ICalendarEntity for XGeoProperty {
                 tag("X-GEO"),
                 cut(
                     map(
-                        pair(
-                            opt(XGeoPropertyParams::parse_ical),
-                            preceded(
-                                colon,
-                                tuple((Float::parse_ical, semicolon, Float::parse_ical)),
-                            ),
+                        tuple(
+                            (
+                                opt(tag("-NOT")),
+                                opt(XGeoPropertyParams::parse_ical),
+                                preceded(
+                                    colon,
+                                    tuple((Float::parse_ical, semicolon, Float::parse_ical)),
+                                ),
+                            )
                         ),
-                        |(params, (latitude, _, longitude))| {
+                        |(not, params, (latitude, _, longitude))| {
                             XGeoProperty {
                                 params: params.unwrap_or(XGeoPropertyParams::default()),
                                 latitude,
                                 longitude,
-                                negated: false,
+                                negated: not.is_some(),
                             }
                         }
                     )
@@ -135,8 +143,10 @@ impl ICalendarProperty for XGeoProperty {
     /// Build a `ContentLineParams` instance with consideration to the optionally provided
     /// `RenderingContext`.
     fn to_content_line_with_context(&self, _context: Option<&RenderingContext>) -> ContentLine {
+        let property = if self.negated { "X-GEO-NOT" } else { "X-GEO" };
+
         ContentLine::from((
-            "X-GEO",
+            property,
             (
                 ContentLineParams::from(&self.params),
                 format!("{};{}", self.latitude.render_ical(), self.longitude.render_ical()),
@@ -189,6 +199,19 @@ mod tests {
         );
 
         assert_parser_output!(
+            XGeoProperty::parse_ical("X-GEO-NOT:48.85299;2.36885 DESCRIPTION:Description text".into()),
+            (
+                " DESCRIPTION:Description text",
+                XGeoProperty {
+                    params: XGeoPropertyParams { dist: DistValue::Kilometers(Float(10.0_f64)) },
+                    latitude: Float(48.85299_f64),
+                    longitude: Float(2.36885_f64),
+                    negated: true,
+                },
+            ),
+        );
+
+        assert_parser_output!(
             XGeoProperty::parse_ical("X-GEO;DIST=1.5KM:48.85299;2.36885 DESCRIPTION:Description text".into()),
             (
                 " DESCRIPTION:Description text",
@@ -202,6 +225,19 @@ mod tests {
         );
 
         assert_parser_output!(
+            XGeoProperty::parse_ical("X-GEO-NOT;DIST=1.5KM:48.85299;2.36885 DESCRIPTION:Description text".into()),
+            (
+                " DESCRIPTION:Description text",
+                XGeoProperty {
+                    params: XGeoPropertyParams { dist: DistValue::Kilometers(Float(1.5_f64)) },
+                    latitude: Float(48.85299_f64),
+                    longitude: Float(2.36885_f64),
+                    negated: true,
+                },
+            ),
+        );
+
+        assert_parser_output!(
             XGeoProperty::parse_ical("X-GEO;DIST=30MI:48.85299;2.36885 DESCRIPTION:Description text".into()),
             (
                 " DESCRIPTION:Description text",
@@ -210,6 +246,19 @@ mod tests {
                     latitude: Float(48.85299_f64),
                     longitude: Float(2.36885_f64),
                     negated: false,
+                },
+            ),
+        );
+
+        assert_parser_output!(
+            XGeoProperty::parse_ical("X-GEO-NOT;DIST=30MI:48.85299;2.36885 DESCRIPTION:Description text".into()),
+            (
+                " DESCRIPTION:Description text",
+                XGeoProperty {
+                    params: XGeoPropertyParams { dist: DistValue::Miles(Float(30.0_f64)) },
+                    latitude: Float(48.85299_f64),
+                    longitude: Float(2.36885_f64),
+                    negated: true,
                 },
             ),
         );
@@ -231,12 +280,32 @@ mod tests {
 
         assert_eq!(
             XGeoProperty {
+                params: XGeoPropertyParams { dist: DistValue::Kilometers(Float(1.5_f64)) },
+                latitude: Float(48.85299_f64),
+                longitude: Float(2.36885_f64),
+                negated: true,
+            }.render_ical(),
+            String::from("X-GEO-NOT;DIST=1.5KM:48.85299;2.36885"),
+        );
+
+        assert_eq!(
+            XGeoProperty {
                 params: XGeoPropertyParams { dist: DistValue::Miles(Float(30.0_f64)) },
                 latitude: Float(48.85299_f64),
                 longitude: Float(2.36885_f64),
                 negated: false,
             }.render_ical(),
             String::from("X-GEO;DIST=30MI:48.85299;2.36885"),
+        );
+
+        assert_eq!(
+            XGeoProperty {
+                params: XGeoPropertyParams { dist: DistValue::Miles(Float(30.0_f64)) },
+                latitude: Float(48.85299_f64),
+                longitude: Float(2.36885_f64),
+                negated: true,
+            }.render_ical(),
+            String::from("X-GEO-NOT;DIST=30MI:48.85299;2.36885"),
         );
     }
 }

--- a/redical_ical/src/properties/query/x_location_type.rs
+++ b/redical_ical/src/properties/query/x_location_type.rs
@@ -71,6 +71,7 @@ impl Default for XLocationTypePropertyParams {
 pub struct XLocationTypeProperty {
     pub params: XLocationTypePropertyParams,
     pub types: List<Text>,
+    pub negated: bool,
 }
 
 impl ICalendarEntity for XLocationTypeProperty {
@@ -89,6 +90,7 @@ impl ICalendarEntity for XLocationTypeProperty {
                             XLocationTypeProperty {
                                 params: params.unwrap_or(XLocationTypePropertyParams::default()),
                                 types,
+                                negated: false,
                             }
                         }
                     )
@@ -150,6 +152,7 @@ mod tests {
                 XLocationTypeProperty {
                     params: XLocationTypePropertyParams { op: WhereOperator::And },
                     types: List::from(vec![Text(String::from("RESTAURANT")), Text(String::from("HOTEL"))]),
+                    negated: false,
                 },
             ),
         );
@@ -161,6 +164,7 @@ mod tests {
                 XLocationTypeProperty {
                     params: XLocationTypePropertyParams { op: WhereOperator::And },
                     types: List::from(vec![Text(String::from("RESTAURANT")), Text(String::from("HOTEL"))]),
+                    negated: false,
                 },
             ),
         );
@@ -172,6 +176,7 @@ mod tests {
                 XLocationTypeProperty {
                     params: XLocationTypePropertyParams { op: WhereOperator::Or },
                     types: List::from(vec![Text(String::from("RESTAURANT")), Text(String::from("HOTEL"))]),
+                    negated: false,
                 },
             ),
         );
@@ -186,6 +191,7 @@ mod tests {
             XLocationTypeProperty {
                 params: XLocationTypePropertyParams { op: WhereOperator::And },
                 types: List::from(vec![Text(String::from("RESTAURANT")), Text(String::from("HOTEL"))]),
+                negated: false,
             }.render_ical(),
             String::from("X-LOCATION-TYPE;OP=AND:HOTEL,RESTAURANT"),
         );
@@ -194,6 +200,7 @@ mod tests {
             XLocationTypeProperty {
                 params: XLocationTypePropertyParams { op: WhereOperator::Or },
                 types: List::from(vec![Text(String::from("RESTAURANT")), Text(String::from("HOTEL"))]),
+                negated: false,
             }.render_ical(),
             String::from("X-LOCATION-TYPE;OP=OR:HOTEL,RESTAURANT"),
         );

--- a/redical_ical/src/properties/query/x_related_to.rs
+++ b/redical_ical/src/properties/query/x_related_to.rs
@@ -79,6 +79,7 @@ impl Default for XRelatedToPropertyParams {
 pub struct XRelatedToProperty {
     pub params: XRelatedToPropertyParams,
     pub uids: List<Text>,
+    pub negated: bool,
 }
 
 impl ICalendarEntity for XRelatedToProperty {
@@ -97,6 +98,7 @@ impl ICalendarEntity for XRelatedToProperty {
                             XRelatedToProperty {
                                 params: params.unwrap_or(XRelatedToPropertyParams::default()),
                                 uids,
+                                negated: false,
                             }
                         }
                     )
@@ -170,6 +172,7 @@ mod tests {
                         op: WhereOperator::And,
                     },
                     uids: List::from(vec![Text(String::from("parent.uid.one")), Text(String::from("parent.uid.two"))]),
+                    negated: false,
                 },
             ),
         );
@@ -184,6 +187,7 @@ mod tests {
                         op: WhereOperator::Or,
                     },
                     uids: List::from(vec![Text(String::from("x-reltype.uid.one")), Text(String::from("x-reltype.uid.two"))]),
+                    negated: false,
                 },
             ),
         );
@@ -200,6 +204,7 @@ mod tests {
                     op: WhereOperator::And,
                 },
                 uids: List::from(vec![Text(String::from("parent.uid.one")), Text(String::from("parent.uid.two"))]),
+                negated: false,
             }.render_ical(),
             String::from("X-RELATED-TO;RELTYPE=PARENT;OP=AND:parent.uid.one,parent.uid.two"),
         );
@@ -211,6 +216,7 @@ mod tests {
                     op: WhereOperator::Or,
                 },
                 uids: List::from(vec![Text(String::from("x-reltype.uid.one")), Text(String::from("x-reltype.uid.two"))]),
+                negated: false,
             }.render_ical(),
             String::from("X-RELATED-TO;RELTYPE=X-RELTYPE;OP=OR:x-reltype.uid.one,x-reltype.uid.two"),
         );

--- a/redical_ical/src/properties/query/x_uid.rs
+++ b/redical_ical/src/properties/query/x_uid.rs
@@ -22,6 +22,7 @@ use crate::{RenderingContext, ICalendarEntity, ParserInput, ParserResult, impl_i
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct XUIDProperty {
     pub uids: List<Text>,
+    pub negated: bool,
 }
 
 impl ICalendarEntity for XUIDProperty {
@@ -36,6 +37,7 @@ impl ICalendarEntity for XUIDProperty {
                         |uids| {
                             XUIDProperty {
                                 uids,
+                                negated: false,
                             }
                         }
                     )
@@ -96,6 +98,7 @@ mod tests {
                 " DESCRIPTION:Description text",
                 XUIDProperty {
                     uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
+                    negated: false,
                 },
             ),
         );
@@ -106,6 +109,7 @@ mod tests {
                 " DESCRIPTION:Description text",
                 XUIDProperty {
                     uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
+                    negated: false,
                 },
             ),
         );
@@ -116,6 +120,7 @@ mod tests {
                 " DESCRIPTION:Description text",
                 XUIDProperty {
                     uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
+                    negated: false,
                 },
             ),
         );
@@ -130,6 +135,7 @@ mod tests {
         assert_eq!(
             XUIDProperty {
                 uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
+                negated: false,
             }.render_ical(),
             String::from("X-UID:UID_ONE,UID_TWO"),
         );
@@ -137,6 +143,7 @@ mod tests {
         assert_eq!(
             XUIDProperty {
                 uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
+                negated: false,
             }.render_ical(),
             String::from("X-UID:UID_ONE,UID_TWO"),
         );

--- a/redical_ical/src/properties/query/x_uid.rs
+++ b/redical_ical/src/properties/query/x_uid.rs
@@ -93,22 +93,11 @@ mod tests {
     #[test]
     fn parse_ical() {
         assert_parser_output!(
-            XUIDProperty::parse_ical("X-UID:UID_ONE,UID_TWO DESCRIPTION:Description text".into()),
+            XUIDProperty::parse_ical("X-UID:UID_ONE DESCRIPTION:Description text".into()),
             (
                 " DESCRIPTION:Description text",
                 XUIDProperty {
-                    uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
-                    negated: false,
-                },
-            ),
-        );
-
-        assert_parser_output!(
-            XUIDProperty::parse_ical("X-UID:UID_ONE,UID_TWO DESCRIPTION:Description text".into()),
-            (
-                " DESCRIPTION:Description text",
-                XUIDProperty {
-                    uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
+                    uids: List::from(vec![Text(String::from("UID_ONE"))]),
                     negated: false,
                 },
             ),
@@ -134,10 +123,10 @@ mod tests {
     fn render_ical() {
         assert_eq!(
             XUIDProperty {
-                uids: List::from(vec![Text(String::from("UID_ONE")), Text(String::from("UID_TWO"))]),
+                uids: List::from(vec![Text(String::from("UID_ONE"))]),
                 negated: false,
             }.render_ical(),
-            String::from("X-UID:UID_ONE,UID_TWO"),
+            String::from("X-UID:UID_ONE"),
         );
 
         assert_eq!(


### PR DESCRIPTION
- This PR updates the following query properties to be able to be negated via a new syntax:
    * `X-CATEGORIES` and `X-CATEGORIES-NOT`
    * `X-CLASS` and `X-CLASS-NOT`
    * `X-GEO` and `X-GEO-NOT`
    * `X-LOCATION-TYPE` and `X-LOCATION-TYPE-NOT`
    * `X-RELATED-TO` and `X-RELATED-TO-NOT`
    * `X-UID` and `X-UID-NOT`

- This was acheived by adding a default `false` bool field to each of the aforementioned properties, and updating this to `true` if the query property name is followed by `-NOT`
- I decided against another variant on the `WhereOperator` enum as this would cause confusion downstream, and the use case for these binary operators is not the same as the unary not operator.
- We will need to be careful with how the `NOT` and other where operators `AND, OR` interact at the `query_parser`. Without jumping the gun, I suggest we always use `AND` for `NOT` clauses and update the parser accordingly to restrict this.
- Remember that `AND NOT` and `OR NOT` are not first-class citizen operators, but are combinations. So we can still get "`OR NOT`" functionality by joining groups: e.g. `(X-PROP-NOT:FOO) OR (X-PROP-NOT:BAR)`

## Example

`X-CATEGORIES:ONE` => where categories = ONE
`X-CATEGORIES-NOT:ONE` => where categories != ONE
`X-CATEGORIES-NOT:ONE,TWO` => where categories != ONE AND categories != TWO
`X-CATEGORIES-NOT;OP=OR:ONE,TWO` => undefined behaviour for now - worry about this later
