### PR TITLE
Negated Operator Restriction

### DIFF
--- a/redical_core/src/queries/query_parser.rs
+++ b/redical_core/src/queries/query_parser.rs
@@ -165,12 +165,14 @@ macro_rules! fold_negated_terms {
     }}
 }
 
+// Operator is hardcoded for UIDs due to the mutual exclusivity between separate
+// events (ie an event can't have multiple UIDs).
 fn build_uid_property_condition(property: &XUIDProperty) -> Option<WhereConditional> {
     if property.negated {
         fold_negated_terms!(
             UID,
             property.get_uids(),
-            WhereOperator::Or
+            WhereOperator::And
         )
     } else {
         fold_terms!(

--- a/redical_core/src/queries/query_parser.rs
+++ b/redical_core/src/queries/query_parser.rs
@@ -368,7 +368,7 @@ mod test {
     use crate::{GeoDistance, KeyValuePair};
 
     #[test]
-    fn test_build_class_property_condition_condition() {
+    fn test_build_class_property_condition() {
         assert_eq!(
             build_class_property_condition(&build_property_from_ical!(XClassProperty, "X-CLASS:")),
             None,
@@ -406,7 +406,7 @@ mod test {
     }
 
     #[test]
-    fn test_build_categories_property_condition_condition() {
+    fn test_build_categories_property_condition() {
         assert_eq!(
             build_categories_property_condition(&build_property_from_ical!(XCategoriesProperty, "X-CATEGORIES:")),
             None,
@@ -442,7 +442,7 @@ mod test {
     }
 
     #[test]
-    fn test_build_related_to_property_condition_condition() {
+    fn test_build_related_to_property_condition() {
         assert_eq!(
             build_related_to_property_condition(&build_property_from_ical!(XRelatedToProperty, "X-RELATED-TO:")),
             None,

--- a/tests/integration.rs
+++ b/tests/integration.rs
@@ -1766,6 +1766,87 @@ mod integration {
             ]
         );
 
+        // Assert negative querying by UID
+        query_calendar_and_assert_matching_event_instances!(
+            connection,
+            "TEST_CALENDAR_UID",
+            [
+                "(X-UID-NOT:EVENT_IN_CHELTENHAM_TUE_THU,OVERRIDDEN_EVENT_IN_BRISTOL_TUE_THU)",
+                "X-LIMIT:4",
+                "X-OFFSET:0",
+                "X-TZID:Europe/Vilnius",
+                "X-ORDER-BY:DTSTART-GEO-DIST;51.454481838260214;-2.588329192623361",
+            ],
+            [
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20201231T200000",
+                        "X-GEO-DIST:111.491952KM",
+                    ],
+                    [
+                        "CATEGORIES:CATEGORY_ONE,CATEGORY_THREE",
+                        "DTEND;TZID=Europe/Vilnius:20201231T203000",
+                        "DTSTART;TZID=Europe/Vilnius:20201231T200000",
+                        "DURATION:PT30M",
+                        "GEO:51.45442303961853;-0.9792277140273513",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20201231T200000",
+                        "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
+                        "SUMMARY:Event in Reading on Tuesdays and Thursdays at 6:00PM",
+                        "UID:EVENT_IN_READING_TUE_THU",
+                    ],
+                ],
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20201231T203000",
+                        "X-GEO-DIST:170.540546KM",
+                    ],
+                    [
+                        "CATEGORIES:CATEGORY_FOUR,CATEGORY_ONE",
+                        "DTEND;TZID=Europe/Vilnius:20201231T210000",
+                        "DTSTART;TZID=Europe/Vilnius:20201231T203000",
+                        "DURATION:PT30M",
+                        "GEO:51.50740017561507;-0.12698231869919185",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20201231T203000",
+                        "RELATED-TO;RELTYPE=PARENT:PARENT_UID",
+                        "SUMMARY:Event in London on Tuesdays and Thursdays at 6:30PM",
+                        "UID:EVENT_IN_LONDON_TUE_THU",
+                    ],
+                ],
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20210104T180000",
+                    ],
+                    [
+                        "CATEGORIES:CATEGORY TWO,CATEGORY_ONE",
+                        "DTEND;TZID=Europe/Vilnius:20210104T190000",
+                        "DTSTART;TZID=Europe/Vilnius:20210104T180000",
+                        "DURATION:PT1H",
+                        "LOCATION-TYPE:DIGITAL,ONLINE",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20210104T180000",
+                        "SUMMARY:Online Event on Mondays and Wednesdays at 4:00PM",
+                        "UID:ONLINE_EVENT_MON_WED",
+                    ],
+                ],
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20210104T190000",
+                        "X-GEO-DIST:97.489206KM",
+                    ],
+                    [
+                        "CATEGORIES:OVERRIDDEN_CATEGORY",
+                        "DTEND;TZID=Europe/Vilnius:20210104T193000",
+                        "DTSTART;TZID=Europe/Vilnius:20210104T190000",
+                        "DURATION:PT30M",
+                        "GEO:51.751365550307604;-1.2601196837753945",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20210104T190000",
+                        "RELATED-TO;RELTYPE=PARENT:OVERRIDDEN_PARENT_UID",
+                        "SUMMARY:Overridden event in Oxford summary text",
+                        "UID:EVENT_IN_OXFORD_MON_WED",
+                    ],
+                ],
+            ]
+        );
+
         assert_error_returned!(
             connection,
             "Error: - expected iCalendar RFC-5545 DATE-VALUE (DATE-FULLYEAR DATE-MONTH DATE-MDAY) at \"41T180000Z\" -- Context: X-UNTIL -> DATE-TIME -> DATE",
@@ -2074,6 +2155,89 @@ mod integration {
                 "LAST-MODIFIED:20210501T090000Z",
                 "GEO:51.45442303961853;-0.9792277140273513",
             ],
+        );
+
+        // Assert negative querying by UID
+        query_calendar_and_assert_matching_event_instances!(
+            connection,
+            "TEST_CALENDAR_UID",
+            [
+                "(X-UID-NOT:ONLINE_EVENT_MON_WED,OVERRIDDEN_EVENT_IN_BRISTOL_TUE_THU)",
+                "X-LIMIT:4",
+                "X-OFFSET:0",
+                "X-TZID:Europe/Vilnius",
+                "X-ORDER-BY:DTSTART-GEO-DIST;51.454481838260214;-2.588329192623361",
+            ],
+            [
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20201231T200000",
+                        "X-GEO-DIST:111.491952KM",
+                    ],
+                    [
+                        "DTEND;TZID=Europe/Vilnius:20201231T203000",
+                        "DTSTART;TZID=Europe/Vilnius:20201231T200000",
+                        "DURATION:PT30M",
+                        "GEO:51.45442303961853;-0.9792277140273513",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20201231T200000",
+                        "SUMMARY:Event in Reading on Tuesdays and Thursdays at 6:00PM",
+                        "UID:EVENT_IN_READING_TUE_THU",
+                    ],
+                ],
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20201231T203000",
+                        "X-GEO-DIST:170.540546KM",
+                    ],
+                    [
+                        "CATEGORIES:OVERRIDDEN_CATEGORY",
+                        "CLASS:OVERRIDDEN",
+                        "DTEND;TZID=Europe/Vilnius:20201231T210000",
+                        "DTSTART;TZID=Europe/Vilnius:20201231T203000",
+                        "DURATION:PT30M",
+                        "GEO:51.50740017561507;-0.12698231869919185",
+                        "LOCATION-TYPE:OVERRIDDEN_TYPE",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20201231T203000",
+                        "RELATED-TO;RELTYPE=PARENT:OVERIDDEN_UID",
+                        "SUMMARY:Overridden Event in Cheltenham running in London",
+                        "UID:EVENT_IN_CHELTENHAM_TUE_THU",
+                    ],
+                ],
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20201231T223000",
+                        "X-GEO-DIST:170.540546KM",
+                    ],
+                    [
+                        "CATEGORIES:OVERRIDDEN_CATEGORY",
+                        "CLASS:OVERRIDDEN",
+                        "DTEND;TZID=Europe/Vilnius:20201231T230000",
+                        "DTSTART;TZID=Europe/Vilnius:20201231T223000",
+                        "DURATION:PT30M",
+                        "GEO:51.50740017561507;-0.12698231869919185",
+                        "LOCATION-TYPE:OVERRIDDEN_TYPE",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20201231T223000",
+                        "RELATED-TO;RELTYPE=PARENT:OVERIDDEN_UID",
+                        "SUMMARY:Overridden Event in Bristol running in London",
+                        "UID:EVENT_IN_BRISTOL_TUE_THU",
+                    ],
+                ],
+                [
+                    [
+                        "DTSTART;TZID=Europe/Vilnius:20210105T200000",
+                        "X-GEO-DIST:111.491952KM",
+                    ],
+                    [
+                        "DTEND;TZID=Europe/Vilnius:20210105T203000",
+                        "DTSTART;TZID=Europe/Vilnius:20210105T200000",
+                        "DURATION:PT30M",
+                        "GEO:51.45442303961853;-0.9792277140273513",
+                        "RECURRENCE-ID;VALUE=DATE-TIME;TZID=Europe/Vilnius:20210105T200000",
+                        "SUMMARY:Event in Reading on Tuesdays and Thursdays at 6:00PM",
+                        "UID:EVENT_IN_READING_TUE_THU",
+                    ],
+                ]
+            ]
         );
 
         // Assert comprehensive impossible query


### PR DESCRIPTION
- To minimise any confusion, we have decided to limit negated query clauses to only be compatible with the "AND" operator, when more than one term is specified.
- E.g. `X-CATEGORIES-NOT:FOO,BAR` means `NOT FOO` and `NOT BAR`
- The parser will now raise an error when trying to specify an incompatible operator with a negated property clause.
- Similarly, the `X-UID-NOT` clause has been updated to hardcode the operator as `AND`
- `OR NOT` can still be utilised by grouping desired clauses
- E.g.
    * `X-CATEGORIES-NOT;OP=OR:FOO,BAR` is invalid
    * `(X-CATEGORIES-NOT:FOO OR X-CATEGORIES-NOT:BAR)` is valid
